### PR TITLE
chore: update to v2

### DIFF
--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/Analytics.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/Analytics.kt
@@ -53,17 +53,25 @@ object Analytics : TopsortAnalytics {
         val impressionEvent = ImpressionEvent(
             session = session!!,
             impressions = impressions,
-            occurredAt = eventTime()
         )
 
         val recordId = Cache.storeImpression(impressionEvent)
         enqueueEventRequest(recordId, EventType.Impression)
     }
 
-    override fun reportImpressionWithResolvedBidId(resolvedBidId: String, placement: Placement) {
+    override fun reportImpressionWithResolvedBidId(
+        resolvedBidId: String,
+        placement: Placement,
+        opaqueUserId: String,
+        id: String,
+        occurredAt: String?,
+    ) {
         val impression = Impression(
             resolvedBidId = resolvedBidId,
-            placement = placement
+            placement = placement,
+            opaqueUserId = opaqueUserId,
+            id = id,
+            occurredAt = occurredAt ?: eventTime(),
         )
 
         reportImpression(listOf(impression))
@@ -71,10 +79,10 @@ object Analytics : TopsortAnalytics {
 
     override fun reportClick(
         placement: Placement,
-        productId: String?,
-        auctionId: String?,
-        id: String?,
+        opaqueUserId: String,
+        id: String,
         resolvedBidId: String?,
+        occurredAt: String?,
     ) {
         if (!assertSetup()) {
             Log.e(LOG_TAG, INVALID_CONFIG_ERROR_MESSAGE)
@@ -83,28 +91,41 @@ object Analytics : TopsortAnalytics {
 
         val clickEvent = ClickEvent(
             session = session!!,
-            placement = placement,
-            productId = productId,
-            auctionId = auctionId,
-            id = id,
-            resolvedBidId = resolvedBidId,
-            occurredAt = eventTime()
+            clicks = listOf(
+                Click(
+                    placement = placement,
+                    opaqueUserId = opaqueUserId,
+                    id = id,
+                    resolvedBidId = resolvedBidId,
+                    occurredAt = occurredAt ?: eventTime()
+                )
+            )
+
         )
 
         val recordId = Cache.storeClick(clickEvent)
         enqueueEventRequest(recordId, EventType.Click)
     }
 
-    override fun reportClickWithResolvedBidId(resolvedBidId: String, placement: Placement) {
+    override fun reportClickWithResolvedBidId(
+        resolvedBidId: String,
+        placement: Placement,
+        opaqueUserId: String,
+        id: String,
+    ) {
         reportClick(
+            resolvedBidId = resolvedBidId,
             placement = placement,
-            resolvedBidId = resolvedBidId
+            opaqueUserId = opaqueUserId,
+            id = id,
         )
     }
 
     override fun reportPurchase(
         items: List<PurchasedItem>,
-        id: String?
+        id: String,
+        opaqueUserId: String,
+        occurredAt: String?,
     ) {
         if (!assertSetup()) {
             Log.e(LOG_TAG, INVALID_CONFIG_ERROR_MESSAGE)
@@ -113,9 +134,14 @@ object Analytics : TopsortAnalytics {
 
         val purchaseEvent = PurchaseEvent(
             session = session!!,
-            id = id,
-            items = items,
-            purchasedAt = eventTime()
+            purchases = listOf(
+                Purchase(
+                    id = id,
+                    items = items,
+                    occurredAt = occurredAt ?: eventTime(),
+                    opaqueUserId = opaqueUserId,
+                ),
+            ),
         )
 
         val recordId = Cache.storePurchase(purchaseEvent)

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/TopsortAnalytics.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/TopsortAnalytics.kt
@@ -18,22 +18,26 @@ interface TopsortAnalytics {
      */
     fun reportImpressionWithResolvedBidId(
         resolvedBidId: String,
-        placement: Placement
+        placement: Placement,
+        opaqueUserId: String,
+        id: String,
+        occurredAt: String? = null,
     )
 
     /**
      * Reports a click event
      *
-     * @param productId The product that was clicked.
-     * @param auctionId Required for promoted products. Must be the ID for the auction the product won
+     * @param opaqueUserId The opaque user ID which allows correlating user activity.
      * @param id The marketplace's unique ID for the click
+     * @param resolvedBidId Required for promoted products. Must be the ID for the auction the product won
+     * @param occurredAt RFC3339 formatted timestamp including UTC offset. Defaults to DateTime() when null
      */
     fun reportClick(
         placement: Placement,
-        productId: String? = null,
-        auctionId: String? = null,
-        id: String? = null,
+        opaqueUserId: String,
+        id: String,
         resolvedBidId: String? = null,
+        occurredAt: String? = null,
     )
 
     /**
@@ -41,16 +45,22 @@ interface TopsortAnalytics {
      */
     fun reportClickWithResolvedBidId(
         resolvedBidId: String,
-        placement: Placement
+        placement: Placement,
+        opaqueUserId: String,
+        id: String,
     )
 
     /**
      * Reports a purchase event.
      *  @param items the list of purchased items
      *  @param id The marketplace assigned ID for the order
+     *  @param opaqueUserId The opaque user ID which allows correlating user activity.
+     *  @param occurredAt RFC3339 formatted timestamp including UTC offset. Defaults to DateTime() when null
      */
     fun reportPurchase(
         items: List<PurchasedItem>,
-        id: String? = null,
+        id: String,
+        opaqueUserId: String,
+        occurredAt: String? = null,
     )
 }

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/TopsortAnalytics.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/TopsortAnalytics.kt
@@ -15,6 +15,11 @@ interface TopsortAnalytics {
 
     /**
      * Reports a single impression with the provided resolvedBidId
+     *
+     * @param opaqueUserId The opaque user ID which allows correlating user activity.
+     * @param id The marketplace's unique ID for the impression
+     * @param resolvedBidId Required for promoted products. Must be the ID for the auction the product won
+     * @param occurredAt RFC3339 formatted timestamp including UTC offset. Defaults to DateTime() when null
      */
     fun reportImpressionWithResolvedBidId(
         resolvedBidId: String,

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/model/ClickEvent.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/model/ClickEvent.kt
@@ -3,24 +3,44 @@ package com.topsort.analytics.model
 data class ClickEvent(
     private val eventType: EventType = EventType.Click,
     val session: Session,
+    val clicks: List<Click>,
+)
+
+data class Click(
+
+    /**
+     * Required for promoted products. Must be the ID for the auction the product won.
+     */
+    val resolvedBidId: String? = null,
+
+    /**
+     * Entity is meant for reporting organic events, not sponsored or promoted products.
+     * It refers to the object involved in the organic interaction.
+     */
+    val entity: Entity? = null,
+
     val placement: Placement,
 
     /**
-     * The product that was clicked.
+     * RFC3339 formatted timestamp including UTC offset.
      */
-    val productId: String? = null,
+    val occurredAt: String,
 
     /**
-     * Required for promoted products. Must be the ID for the auction the product won
+     * The opaque user ID which allows correlating user activity.
      */
-    val auctionId: String? = null,
+    val opaqueUserId: String,
 
     /**
-     * The marketplace's unique ID for the click
+     * The marketplace's ID for the click
      */
-    val id: String? = null,
-    val resolvedBidId: String? = null,
-    val occurredAt: String? = null
+    val id: String,
+
+    /**
+     * Extra attribution if desired by the marketplace.
+     * When using this field, the resolvedBidId must also exist in the event body.
+     */
+    val additionalAttribution: String? = null,
 )
 
 internal data class ClickEventResponse(

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/model/ClickEvent.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/model/ClickEvent.kt
@@ -19,6 +19,12 @@ data class Click(
      */
     val entity: Entity? = null,
 
+    /**
+     * Extra attribution if desired by the marketplace.
+     * When using this field, the resolvedBidId must also exist in the event body.
+     */
+    val additionalAttribution: String? = null,
+
     val placement: Placement,
 
     /**
@@ -35,12 +41,6 @@ data class Click(
      * The marketplace's ID for the click
      */
     val id: String,
-
-    /**
-     * Extra attribution if desired by the marketplace.
-     * When using this field, the resolvedBidId must also exist in the event body.
-     */
-    val additionalAttribution: String? = null,
 )
 
 internal data class ClickEventResponse(

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/model/Entity.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/model/Entity.kt
@@ -1,0 +1,12 @@
+package com.topsort.analytics.model
+
+enum class EntityType {
+
+    Product,
+    Vendor,
+}
+
+data class Entity(
+    val id: Session,
+    val type: EntityType,
+)

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/model/Entity.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/model/Entity.kt
@@ -7,6 +7,14 @@ enum class EntityType {
 }
 
 data class Entity(
-    val id: Session,
+
+    /**
+     * The marketplace's ID of the entity associated with the interaction
+     */
+    val id: Int,
+
+    /**
+     * The type of entity associated with the interaction.
+     */
     val type: EntityType,
 )

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/model/ImpressionEvent.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/model/ImpressionEvent.kt
@@ -4,28 +4,43 @@ data class ImpressionEvent(
     private val eventType: EventType = EventType.Impression,
     val session: Session,
     val impressions: List<Impression>,
-    val occurredAt: String? = null
 )
 
 data class Impression(
-    val placement: Placement,
-
-    /**
-     * The product that was rendered
-     */
-    val productId: String? = null,
 
     /**
      * Required for promoted products. Must be the ID for the auction the product won.
      */
-    val auctionId: String? = null,
+    val resolvedBidId: String? = null,
+
+    /**
+     * Entity is meant for reporting organic events, not sponsored or promoted products.
+     * It refers to the object involved in the organic interaction.
+     */
+    val entity: Entity? = null,
+
+    val placement: Placement,
+
+    /**
+     * RFC3339 formatted timestamp including UTC offset.
+     */
+    val occurredAt: String,
+
+    /**
+     * The opaque user ID which allows correlating user activity.
+     */
+    val opaqueUserId: String,
 
     /**
      * The marketplace's ID for the impression
      */
-    val id: String? = null,
+    val id: String,
 
-    val resolvedBidId: String? = null
+    /**
+     * Extra attribution if desired by the marketplace.
+     * When using this field, the resolvedBidId must also exist in the event body.
+     */
+    val additionalAttribution: String? = null,
 )
 
 internal data class ImpressionEventResponse(

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/model/ImpressionEvent.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/model/ImpressionEvent.kt
@@ -19,6 +19,12 @@ data class Impression(
      */
     val entity: Entity? = null,
 
+    /**
+     * Extra attribution if desired by the marketplace.
+     * When using this field, the resolvedBidId must also exist in the event body.
+     */
+    val additionalAttribution: String? = null,
+
     val placement: Placement,
 
     /**
@@ -32,15 +38,9 @@ data class Impression(
     val opaqueUserId: String,
 
     /**
-     * The marketplace's ID for the impression
+     * The marketplace assigned ID for the order
      */
     val id: String,
-
-    /**
-     * Extra attribution if desired by the marketplace.
-     * When using this field, the resolvedBidId must also exist in the event body.
-     */
-    val additionalAttribution: String? = null,
 )
 
 internal data class ImpressionEventResponse(

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/model/Placement.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/model/Placement.kt
@@ -1,10 +1,49 @@
 package com.topsort.analytics.model
 
 data class Placement(
+
     /**
-     * A marketplace assigned name for a page
+     * URL path of the page triggering the event.
+     *
+     * For web apps, this can be obtained in JS using window.location.pathname.
+     *
+     * For mobile apps, use the deep link for the current view, if available.
+     * Otherwise, encode the view from which the event occurred in your app as a path-like string (e.g. /root/categories/:categoryId).
      */
-    val page: String,
+    val path: String,
+
+    /**
+     * For components with multiple items (i.e. search results, similar products, etc), this should indicate the index of a given item within that list.
+     */
+    val position: Int? = null,
+
+    /**
+     * For paginated pages, this should indicate which page number triggered the event.
+     */
+    val page: Int? = null,
+
+    /**
+     * For paginated pages this should indicate how many items are in each result page.
+     */
+    val pageSize: Int? = null,
+
+    /**
+     * The ID of the product associated to the page in which this event occurred, if applicable.
+     * This ID must match the ID provided through the catalog service.
+     */
+    val productId: String? = null,
+
+    /**
+     * An array of IDs of the categories associated to the page in which this event occurred, if applicable.
+     * These IDs must match the IDs provided through the catalog service.
+     */
+    val categoryIds: List<String>? = null,
+
+    /**
+     * The search string provided by the user in the page where this event occurred, if applicable.
+     * This search string must match the searchQuery field that was provided in the auction request (if provided).
+     */
+    val searchQuery : String? = null,
 
     /**
      * A marketplace defined name for a page part

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/model/PurchaseEvent.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/model/PurchaseEvent.kt
@@ -6,7 +6,6 @@ data class PurchaseEvent(
     private val eventType: EventType = EventType.Purchase,
     val session: Session,
     val purchases: List<Purchase>
-
 )
 
 data class Purchase(
@@ -22,14 +21,14 @@ data class Purchase(
     val opaqueUserId: String,
 
     /**
+     * The marketplace assigned ID for the order
+     */
+    val id: String,
+
+    /**
      * Items purchased
      */
     val items: List<PurchasedItem>,
-
-    /**
-     * The marketplace assigned ID for the order
-     */
-    val id: String
 )
 
 data class PurchasedItem(

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/model/PurchaseEvent.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/model/PurchaseEvent.kt
@@ -5,7 +5,21 @@ import androidx.annotation.IntRange
 data class PurchaseEvent(
     private val eventType: EventType = EventType.Purchase,
     val session: Session,
-    val purchasedAt: String,
+    val purchases: List<Purchase>
+
+)
+
+data class Purchase(
+
+    /**
+     * RFC3339 formatted timestamp including UTC offset.
+     */
+    val occurredAt: String,
+
+    /**
+     * The opaque user ID which allows correlating user activity.
+     */
+    val opaqueUserId: String,
 
     /**
      * Items purchased
@@ -15,7 +29,7 @@ data class PurchaseEvent(
     /**
      * The marketplace assigned ID for the order
      */
-    val id: String?
+    val id: String
 )
 
 data class PurchasedItem(
@@ -31,8 +45,6 @@ data class PurchasedItem(
     /**
      * If known, the product's auction ID if the consumer clicked on a promoted link before purchasing
      */
-    val auctionId: String? = null,
-
     val resolvedBidId: String? = null
 )
 


### PR DESCRIPTION
Updates the entities to use the [v2 API standard](https://docs.topsort.com/reference/reportevents)

Closes: https://topsort.atlassian.net/browse/API-853