### PR TITLE
chore(sdk): remove appcompat and material

### DIFF
--- a/TopsortAnalytics/build.gradle
+++ b/TopsortAnalytics/build.gradle
@@ -38,9 +38,6 @@ dependencies {
 
     implementation 'androidx.core:core-ktx:1.10.1'
 
-    implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'com.google.android.material:material:1.9.0'
-
     //Work Manager
     implementation "androidx.work:work-runtime-ktx:2.8.1"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,7 +45,6 @@ dependencies {
 
     implementation 'androidx.core:core-ktx:1.10.1'
 
-    implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.9.0'
     implementation project(path: ':TopsortAnalytics')
 


### PR DESCRIPTION
Appcompat is not needed
Material is kept as a dependency ony with the bundled example `app`

Closes: https://topsort.atlassian.net/browse/API-798