### PR TITLE
feat: enable connected android tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,19 +9,52 @@ jobs:
     steps:
     - name: Checkout sources
       uses: actions/checkout@v4
+
+    - name: Enable KVM
+      run: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
+
     - name: Setup Java
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: 17
+
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4
+
     - name: Run tests with Gradle
       run: ./gradlew test
-    - name: Run connected Android tests
+
+    - name: AVD cache
+      uses: actions/cache@v4
+      id: avd-cache
+      with:
+        path: |
+          ~/.android/avd/*
+          ~/.android/adb*
+        key: avd-34
+
+    - name: create AVD and generate snapshot for caching
+      if: steps.avd-cache.outputs.cache-hit != 'true'
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: 34
         arch: x86_64
+        force-avd-creation: false
+        emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+        disable-animations: false
+        script: echo "Generated AVD snapshot for caching."
+
+    - name: Run Android connected tests
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: 34
+        arch: x86_64
+        force-avd-creation: false
+        emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+        disable-animations: true
         script: ./gradlew connectedCheck
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,5 +22,6 @@ jobs:
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: 34
+        arch: x86_64
         script: ./gradlew connectedCheck
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,3 +18,9 @@ jobs:
       uses: gradle/actions/setup-gradle@v4
     - name: Run tests with Gradle
       run: ./gradlew test
+    - name: Run connected Android tests
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: 34
+        script: ./gradlew connectedCheck
+

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.TopsortAnalytics"
         android:name=".TestApplication"
-        tools:targetApi="31" >
+        tools:targetApi="34" >
 
 <!--        <activity-->
 <!--            android:name="com.topsort.analytics.MainActivity"-->

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 #Mon Aug 05 21:51:19 CLT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Followed the steps here: https://github.com/ReactiveCircus/android-emulator-runner
Android connected tests enable us to test android-specific features like WorkManager and DataStore