### PR TITLE
chore: autoapply detekt (static code analysis and linting)

### DIFF
--- a/TopsortAnalytics/build.gradle
+++ b/TopsortAnalytics/build.gradle
@@ -1,6 +1,9 @@
+import io.gitlab.arturbosch.detekt.Detekt
+
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
+    id 'io.gitlab.arturbosch.detekt'
 }
 
 android {
@@ -32,6 +35,10 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+}
+
+tasks.withType(Detekt).configureEach {
+    config = files(["$projectDir/../detekt.yaml"])
 }
 
 dependencies {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,9 +1,12 @@
+import io.gitlab.arturbosch.detekt.Detekt
+
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
+    id 'io.gitlab.arturbosch.detekt'
 }
 
-def config = { k -> "\"${project.properties.get(k)}\"" }
+def properties = { k -> "\"${project.properties.get(k)}\"" }
 
 android {
     namespace 'com.topsort.analytics'
@@ -21,13 +24,13 @@ android {
 
     buildTypes {
         debug {
-            buildConfigField 'String', 'TOKEN', config("topsort.sample.bearertoken")
+            buildConfigField 'String', 'TOKEN', properties("topsort.sample.bearertoken")
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
 
         release {
-            buildConfigField 'String', 'TOKEN', config("topsort.sample.bearertoken")
+            buildConfigField 'String', 'TOKEN', properties("topsort.sample.bearertoken")
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
@@ -42,6 +45,10 @@ android {
     buildFeatures {
         buildConfig = true
     }
+}
+
+tasks.withType(Detekt).configureEach {
+    config = files(["$projectDir/../detekt.yaml"])
 }
 
 dependencies {

--- a/app/src/test/java/com/topsort/analytics/ExampleUnitTest.kt
+++ b/app/src/test/java/com/topsort/analytics/ExampleUnitTest.kt
@@ -1,7 +1,7 @@
 package com.topsort.analytics
 
-import org.junit.Test
 import org.junit.Assert.assertEquals
+import org.junit.Test
 
 /**
  * Example local unit test, which will execute on the development machine (host).

--- a/build.gradle
+++ b/build.gradle
@@ -6,15 +6,16 @@ plugins {
     id 'com.android.application' version '8.5.1' apply false
     id 'com.android.library' version '8.5.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.9.23' apply false
-    id 'io.gitlab.arturbosch.detekt' version '1.23.6'
+    id 'io.gitlab.arturbosch.detekt' version '1.23.6' apply false
 }
 
-tasks.withType(Detekt).configureEach {
-    jvmTarget = '1.8'
-    autoCorrect = true
-    buildUponDefaultConfig = true
-    config = files(["$projectDir/../detekt.yaml"])
-}
-tasks.withType(DetektCreateBaselineTask).configureEach {
-    jvmTarget = '1.8'
+subprojects {
+    tasks.withType(Detekt).configureEach {
+        jvmTarget = '1.8'
+        autoCorrect = true
+        buildUponDefaultConfig = true
+    }
+    tasks.withType(DetektCreateBaselineTask).configureEach {
+        jvmTarget = '1.8'
+    }
 }


### PR DESCRIPTION
Applies Detekt to all projects automatically.
Some notes: 
* The top level gradle file serves to basically define the version of the plugin, it still needs to be applied in each subproject in a plugin block
* The configurations in the subProjects block work for setting the Detekt JVM, but not the config file, so they also need to be set in the project's buildfile
* `config` attribution inside the task name clashes with the `config` macro in the :app buildfile, so I changed the macro to `properites`