### PR TITLE
chore: change sessionid to opaqueuserid

### DIFF
--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/Analytics.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/Analytics.kt
@@ -40,24 +40,24 @@ object Analytics : TopsortAnalytics {
     /**
      * Setup initial properties required for the analytics library,
      * Call this from the Application class, before submitting any event,
-     * Or when a new sessionId or bearer token has to be used.
+     * Or when a new opaqueUserId or bearer token has to be used.
      *
      * @param application The Application instance of the app.
-     * @param sessionId The SessionId allows correlating user activity during a session whether or not they are actually logged in.
+     * @param opaqueUserId The SessionId allows correlating user activity during a session whether or not they are actually logged in.
      * @param token The bearer token
      */
     @SuppressLint("KotlinNullnessAnnotation")
     fun setup(
         @NonNull application: Application,
-        @NonNull sessionId: String,
+        @NonNull opaqueUserId: String,
         @NonNull token: String
     ) {
         applicationContext = application.applicationContext
         workManager = WorkManager.getInstance(applicationContext!!)
-        Cache.setup(application, sessionId, token)
+        Cache.setup(application, opaqueUserId, token)
 
         session = Session(
-            sessionId = sessionId
+            opaqueUserId = opaqueUserId
         )
     }
 
@@ -72,7 +72,7 @@ object Analytics : TopsortAnalytics {
             Impression.Factory.buildPromoted(
                 resolvedBidId = resolvedBidId,
                 placement = placement,
-                opaqueUserId = opaqueUserId ?: session!!.sessionId,
+                opaqueUserId = opaqueUserId ?: session!!.opaqueUserId,
                 id = id?: randomId(),
                 occurredAt = occurredAt ?: eventTime(),
             )
@@ -92,7 +92,7 @@ object Analytics : TopsortAnalytics {
             Impression.Factory.buildOrganic(
                 entity = entity,
                 placement = placement,
-                opaqueUserId = opaqueUserId ?: session!!.sessionId,
+                opaqueUserId = opaqueUserId ?: session!!.opaqueUserId,
                 id = id?: randomId(),
                 occurredAt = occurredAt ?: eventTime(),
             )
@@ -112,7 +112,7 @@ object Analytics : TopsortAnalytics {
             Click.Factory.buildPromoted(
                 resolvedBidId = resolvedBidId,
                 placement = placement,
-                opaqueUserId = opaqueUserId ?: session!!.sessionId,
+                opaqueUserId = opaqueUserId ?: session!!.opaqueUserId,
                 id = id?: randomId(),
                 occurredAt = occurredAt ?: eventTime()
             )
@@ -132,7 +132,7 @@ object Analytics : TopsortAnalytics {
             Click.Factory.buildOrganic(
                 entity = entity,
                 placement = placement,
-                opaqueUserId = opaqueUserId ?: session!!.sessionId,
+                opaqueUserId = opaqueUserId ?: session!!.opaqueUserId,
                 id = id?: randomId(),
                 occurredAt = occurredAt ?: eventTime()
             )
@@ -158,7 +158,7 @@ object Analytics : TopsortAnalytics {
                     id = id,
                     items = items,
                     occurredAt = occurredAt ?: eventTime(),
-                    opaqueUserId = opaqueUserId ?: session!!.sessionId,
+                    opaqueUserId = opaqueUserId ?: session!!.opaqueUserId,
                 ),
             ),
         )

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/Cache.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/Cache.kt
@@ -6,7 +6,7 @@ import android.text.TextUtils
 import com.topsort.analytics.model.ClickEvent
 import com.topsort.analytics.model.ImpressionEvent
 import com.topsort.analytics.model.PurchaseEvent
-import java.util.*
+import java.util.Locale
 
 private const val PREFERENCES_NAME = "TOPSORT_EVENTS_CACHE"
 
@@ -31,7 +31,7 @@ internal object Cache {
                 .apply()
         }
 
-    var sessionId: String = ""
+    private var opaqueUserId: String = ""
         set(value) {
             field = value
             preferences
@@ -45,18 +45,18 @@ internal object Cache {
         preferences = applicationContext.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
 
         token = preferences.getString(KEY_TOKEN, "")!!
-        sessionId = preferences.getString(KEY_SESSION_ID, "")!!
+        opaqueUserId = preferences.getString(KEY_SESSION_ID, "")!!
     }
 
     fun setup(
         context: Context,
-        sessionId: String,
+        opaqueUserId: String,
         token: String
     ) {
         initialize(context)
 
         recentRecordId = preferences.getLong(KEY_RECENT_RECORD_ID, 0)
-        this.sessionId = sessionId
+        this.opaqueUserId = opaqueUserId
         this.token = token
     }
 

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/model/Session.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/model/Session.kt
@@ -1,5 +1,5 @@
 package com.topsort.analytics.model
 
 data class Session(
-    val sessionId: String
+    val opaqueUserId: String
 )

--- a/app/src/main/java/com/topsort/analytics/TestApplication.kt
+++ b/app/src/main/java/com/topsort/analytics/TestApplication.kt
@@ -11,7 +11,7 @@ class TestApplication : Application() {
 
         Analytics.setup(
             application = this,
-            sessionId = sessionId,
+            opaqueUserId = sessionId,
             token = BuildConfig.TOKEN
         )
     }


### PR DESCRIPTION
SessionID was the name for OpaqueUserId in the v1 API
Changing here to make it less confusing