### PR TITLE
chore: add default baseURL

### DIFF
--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/core/ServiceSettings.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/core/ServiceSettings.kt
@@ -1,10 +1,5 @@
 package com.topsort.analytics.core
 
 object ServiceSettings {
-    lateinit var baseApiUrl: String
-    lateinit var bearerToken: String
-
-    fun isSetup() : Boolean{
-        return this::baseApiUrl.isInitialized
-    }
+    var baseApiUrl: String = "https://api.topsort.com/public"
 }

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/core/ServiceSettings.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/core/ServiceSettings.kt
@@ -1,5 +1,5 @@
 package com.topsort.analytics.core
 
 object ServiceSettings {
-    var baseApiUrl: String = "https://api.topsort.com/public"
+    var baseApiUrl: String = "https://api.topsort.com"
 }

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/service/TopsortAuctionsHttpService.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/service/TopsortAuctionsHttpService.kt
@@ -1,10 +1,9 @@
 package com.topsort.analytics.service
 
+import com.topsort.analytics.Cache
 import com.topsort.analytics.core.HttpClient
 import com.topsort.analytics.core.HttpResponse
-import com.topsort.analytics.core.ServiceSettings
 import com.topsort.analytics.core.ServiceSettings.baseApiUrl
-import com.topsort.analytics.core.ServiceSettings.bearerToken
 import com.topsort.analytics.model.auctions.AuctionRequest
 import com.topsort.analytics.model.auctions.AuctionResponse
 
@@ -24,10 +23,9 @@ internal object TopsortAuctionsHttpService {
 
     private fun executeRunAuctions(auctionRequest: AuctionRequest): HttpResponse {
         if(!this::httpClient.isInitialized){
-            assert(ServiceSettings.isSetup())
             httpClient = HttpClient("${baseApiUrl}${AUCTION_ENDPOINT}")
         }
         val json = auctionRequest.toJsonObject().toString()
-        return httpClient.post(json, bearerToken)
+        return httpClient.post(json, Cache.token.ifEmpty { null })
     }
 }


### PR DESCRIPTION
BaseURL is set as a var so we could test against our own mock server, but setting it as `lateinit var` overly complicates setup for customers for no actual gain.

* Setup baseURL with the default public endpoint
* Also removed the secondary bearer token location that was extant from a previous refactoring