### PR TITLE
chore(ci): add Dependabot for Gradle and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: UTC
+    open-pull-requests-limit: 10
+    groups:
+      androidx:
+        patterns: ["androidx.*"]
+      kotlinx:
+        patterns: ["org.jetbrains.kotlinx:*"]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: UTC
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` with weekly scans for Gradle dependencies and GitHub Actions
- Gradle updates are grouped by ecosystem (`androidx.*`, `org.jetbrains.kotlinx:*`) to reduce PR noise
- Actions SHAs are updated weekly, complementing the SHA-pinning added in PR-1

## No prerequisites — safe to merge independently

## Test plan
- [ ] Verify Dependabot PRs appear in the repository on Monday mornings