### PR TITLE
ci: split unit tests and instrumented tests into separate jobs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,64 +5,92 @@ on:
 
 permissions:
   contents: read
+  checks: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  build:
+  unit-tests:
+    name: Unit Tests
     runs-on: ubuntu-22.04
+
     steps:
-    - name: Checkout sources
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - name: Checkout sources
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-    - name: Enable KVM
-      run: |
-        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-        sudo udevadm control --reload-rules
-        sudo udevadm trigger --name-match=kvm
+      - name: Setup Java
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
 
-    - name: Setup Java
-      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
-      with:
-        distribution: 'temurin'
-        java-version: 17
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d  # v4
 
-    - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d  # v4
+      - name: Run unit tests
+        run: ./gradlew :TopsortAnalytics:test
 
-    - name: Run tests with Gradle
-      run: ./gradlew test
+      - name: Publish unit test results
+        uses: mikepenz/action-junit-report@db71d41eb79864e25ab0337e395c352e84523afe  # v4
+        if: always()
+        with:
+          report_paths: '**/build/test-results/test*/*.xml'
+          check_name: Unit Test Results
 
-    - name: AVD cache
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
-      id: avd-cache
-      with:
-        path: |
-          ~/.android/avd/*
-          ~/.android/adb*
-        key: avd-34
+  instrumented-tests:
+    name: Instrumented Tests (API 34)
+    runs-on: ubuntu-22.04
+    needs: unit-tests
 
-    - name: create AVD and generate snapshot for caching
-      if: steps.avd-cache.outputs.cache-hit != 'true'
-      uses: reactivecircus/android-emulator-runner@b530d96654c385303d652368551fb075bc2f0b6b  # v2
-      with:
-        api-level: 34
-        arch: x86_64
-        force-avd-creation: false
-        emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-        disable-animations: false
-        script: echo "Generated AVD snapshot for caching."
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-    - name: Run Android connected tests
-      uses: reactivecircus/android-emulator-runner@b530d96654c385303d652368551fb075bc2f0b6b  # v2
-      with:
-        api-level: 34
-        arch: x86_64
-        force-avd-creation: false
-        emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-        disable-animations: true
-        script: |
-          adb uninstall com.topsort.analytics.test 2>/dev/null || true
-          ./gradlew connectedCheck
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Setup Java
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d  # v4
+
+      - name: AVD cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-34
+
+      - name: Create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@b530d96654c385303d652368551fb075bc2f0b6b  # v2
+        with:
+          api-level: 34
+          arch: x86_64
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
+
+      - name: Run Android connected tests
+        uses: reactivecircus/android-emulator-runner@b530d96654c385303d652368551fb075bc2f0b6b  # v2
+        with:
+          api-level: 34
+          arch: x86_64
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: |
+            adb uninstall com.topsort.analytics.test 2>/dev/null || true
+            ./gradlew :TopsortAnalytics:connectedCheck


### PR DESCRIPTION
## Summary

Replaces the single monolithic `build` job with two jobs:

**`unit-tests`** (fast, no emulator):
- Runs `./gradlew :TopsortAnalytics:test` on `ubuntu-22.04`
- Publishes results as PR check annotations via `mikepenz/action-junit-report`

**`instrumented-tests`** (emulator, `needs: unit-tests`):
- Only runs after unit tests pass — skip the slow AVD spin-up on simple failures
- Runs `./gradlew :TopsortAnalytics:connectedCheck`

Adds `checks: write` permission required by `action-junit-report`.

**Pinned SHA:** `mikepenz/action-junit-report` → `db71d41eb79864e25ab0337e395c352e84523afe` (v4)

## Stacks on: #39 (concurrency groups)

## Test plan
- [ ] Unit test failure stops the run before the emulator starts
- [ ] PR check shows individual test failure annotations