### PR TITLE
chore(build): introduce Gradle version catalog (libs.versions.toml)

### DIFF
--- a/TopsortAnalytics/build.gradle
+++ b/TopsortAnalytics/build.gradle
@@ -1,10 +1,10 @@
 import io.gitlab.arturbosch.detekt.Detekt
 
 plugins {
-    id 'com.android.library'
-    id 'org.jetbrains.kotlin.android'
-    id 'io.gitlab.arturbosch.detekt'
-    id 'com.vanniktech.maven.publish'
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.detekt)
+    alias(libs.plugins.vanniktech.publish)
 }
 
 android {
@@ -47,28 +47,21 @@ tasks.withType(Detekt).configureEach {
 }
 
 dependencies {
+    implementation libs.androidx.core.ktx
+    implementation libs.androidx.annotation
+    implementation libs.androidx.work.runtime
+    implementation libs.androidx.datastore.preferences
+    implementation libs.jodatime
+    implementation libs.coil
 
-    implementation 'androidx.core:core-ktx:1.13.1'
-    implementation 'androidx.annotation:annotation:1.7.1'
+    testImplementation libs.junit4
+    testImplementation libs.org.json
+    testImplementation libs.assertj.core
+    testImplementation libs.mockk
+    testImplementation libs.kotlinx.coroutines.test
 
-    //Work Manager
-    implementation 'androidx.work:work-runtime-ktx:2.9.0'
-    implementation 'androidx.datastore:datastore-preferences:1.1.1'
-
-    //JodaTime
-    implementation group: 'joda-time', name: 'joda-time', version: '2.12.5'
-
-    // Image Loading for Banners
-    implementation 'io.coil-kt:coil:2.7.0'
-
-    testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.json:json:20200518'
-    testImplementation 'org.assertj:assertj-core:3.26.0'
-    testImplementation 'io.mockk:mockk:1.13.12'
-    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3'
-
-    androidTestImplementation 'org.assertj:assertj-core:3.26.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
-    androidTestImplementation 'androidx.work:work-testing:2.9.0'
+    androidTestImplementation libs.assertj.core
+    androidTestImplementation libs.androidx.test.ext.junit
+    androidTestImplementation libs.androidx.test.espresso.core
+    androidTestImplementation libs.androidx.work.testing
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,9 +1,9 @@
 import io.gitlab.arturbosch.detekt.Detekt
 
 plugins {
-    id 'com.android.application'
-    id 'org.jetbrains.kotlin.android'
-    id 'io.gitlab.arturbosch.detekt'
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.detekt)
 }
 
 def properties = { k -> "\"${project.properties.get(k)}\"" }
@@ -56,17 +56,15 @@ tasks.withType(Detekt).configureEach {
 }
 
 dependencies {
-
-    implementation 'androidx.core:core-ktx:1.13.1'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.8.4'
-
-    implementation 'com.google.android.material:material:1.12.0'
+    implementation libs.androidx.core.ktx
+    implementation libs.androidx.lifecycle.runtime
+    implementation libs.material
     implementation project(':TopsortAnalytics')
 
-    testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
-    
-    androidTestImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3'
-    androidTestImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
+    testImplementation libs.junit4
+
+    androidTestImplementation libs.androidx.test.ext.junit
+    androidTestImplementation libs.androidx.test.espresso.core
+    androidTestImplementation libs.kotlinx.coroutines.core
+    androidTestImplementation libs.kotlinx.coroutines.android
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,11 +3,11 @@ import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
 
 plugins {
-    id 'com.android.application' version '8.5.1' apply false
-    id 'com.android.library' version '8.5.1' apply false
-    id 'org.jetbrains.kotlin.android' version '1.9.23' apply false
-    id 'io.gitlab.arturbosch.detekt' version '1.23.6' apply false
-    id 'com.vanniktech.maven.publish' version "0.29.0" apply false
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.android.library)     apply false
+    alias(libs.plugins.kotlin.android)      apply false
+    alias(libs.plugins.detekt)              apply false
+    alias(libs.plugins.vanniktech.publish)  apply false
 }
 
 subprojects {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,47 @@
+[versions]
+agp                    = "8.5.1"
+kotlin                 = "1.9.23"
+detekt                 = "1.23.6"
+vanniktech-publish     = "0.29.0"
+core-ktx               = "1.13.1"
+annotation             = "1.7.1"
+work                   = "2.9.0"
+datastore              = "1.1.1"
+lifecycle              = "2.8.4"
+material               = "1.12.0"
+jodatime               = "2.12.5"
+coil                   = "2.7.0"
+junit4                 = "4.13.2"
+assertj                = "3.26.0"
+org-json               = "20200518"
+androidx-test-ext      = "1.2.1"
+espresso               = "3.6.1"
+kotlinx-coroutines     = "1.7.3"
+mockk                  = "1.13.12"
+
+[libraries]
+androidx-core-ktx              = { module = "androidx.core:core-ktx",                          version.ref = "core-ktx" }
+androidx-annotation            = { module = "androidx.annotation:annotation",                   version.ref = "annotation" }
+androidx-work-runtime          = { module = "androidx.work:work-runtime-ktx",                   version.ref = "work" }
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences",         version.ref = "datastore" }
+androidx-lifecycle-runtime     = { module = "androidx.lifecycle:lifecycle-runtime-ktx",         version.ref = "lifecycle" }
+material                       = { module = "com.google.android.material:material",              version.ref = "material" }
+jodatime                       = { module = "joda-time:joda-time",                              version.ref = "jodatime" }
+coil                           = { module = "io.coil-kt:coil",                                  version.ref = "coil" }
+junit4                         = { module = "junit:junit",                                       version.ref = "junit4" }
+assertj-core                   = { module = "org.assertj:assertj-core",                          version.ref = "assertj" }
+org-json                       = { module = "org.json:json",                                     version.ref = "org-json" }
+androidx-test-ext-junit        = { module = "androidx.test.ext:junit",                          version.ref = "androidx-test-ext" }
+androidx-test-espresso-core    = { module = "androidx.test.espresso:espresso-core",             version.ref = "espresso" }
+androidx-work-testing          = { module = "androidx.work:work-testing",                        version.ref = "work" }
+kotlinx-coroutines-core        = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core",    version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-android     = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-test        = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test",    version.ref = "kotlinx-coroutines" }
+mockk                          = { module = "io.mockk:mockk",                                   version.ref = "mockk" }
+
+[plugins]
+android-application    = { id = "com.android.application",             version.ref = "agp" }
+android-library        = { id = "com.android.library",                 version.ref = "agp" }
+kotlin-android         = { id = "org.jetbrains.kotlin.android",        version.ref = "kotlin" }
+detekt                 = { id = "io.gitlab.arturbosch.detekt",         version.ref = "detekt" }
+vanniktech-publish     = { id = "com.vanniktech.maven.publish",        version.ref = "vanniktech-publish" }


### PR DESCRIPTION
## Summary

- Creates `gradle/libs.versions.toml` with all dependency versions and plugin IDs in one place
- Migrates `build.gradle` (root), `TopsortAnalytics/build.gradle`, and `app/build.gradle` from string literals to `alias(libs.plugins.*)` / `libs.*` catalog references
- Zero functional change — same versions, same dependency graph

## Why

- Single source of truth for all versions (Dependabot bumps land in one file)
- Type-safe accessors reduce typos
- Required prerequisite for adding BCV, Kover, and Dokka plugins cleanly

## Stacks on: #40 (split test jobs)

## Test plan
- [ ] `./gradlew :TopsortAnalytics:dependencies` resolves without errors
- [ ] `./gradlew detekt test` passes