### PR TITLE
ci: add Kover code coverage with 35% enforcement gate

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,6 +32,17 @@ jobs:
       - name: Run unit tests
         run: ./gradlew :TopsortAnalytics:test
 
+      - name: Generate coverage report
+        run: ./gradlew :TopsortAnalytics:koverHtmlReport :TopsortAnalytics:koverVerify
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        if: always()
+        with:
+          name: coverage-report
+          path: TopsortAnalytics/build/reports/kover/html/
+          retention-days: 14
+
       - name: Publish unit test results
         uses: mikepenz/action-junit-report@db71d41eb79864e25ab0337e395c352e84523afe  # v4
         if: always()

--- a/TopsortAnalytics/build.gradle
+++ b/TopsortAnalytics/build.gradle
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.detekt)
     alias(libs.plugins.vanniktech.publish)
     alias(libs.plugins.bcv)
+    alias(libs.plugins.kover)
 }
 
 android {
@@ -45,6 +46,23 @@ kotlin {
 
 tasks.withType(Detekt).configureEach {
     config = files(["$projectDir/../detekt.yaml"])
+}
+
+kover {
+    reports {
+        verify {
+            rule {
+                minBound(35)
+            }
+        }
+        filters {
+            excludes {
+                classes("com.topsort.analytics.BuildConfig")
+                classes("com.topsort.analytics.EventPipeline\$EventEmitterWorker")
+                packages("com.topsort.analytics.worker")
+            }
+        }
+    }
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ plugins {
     alias(libs.plugins.detekt)              apply false
     alias(libs.plugins.vanniktech.publish)  apply false
     alias(libs.plugins.bcv)                 apply false
+    alias(libs.plugins.kover)               apply false
 }
 
 subprojects {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ espresso               = "3.6.1"
 kotlinx-coroutines     = "1.7.3"
 mockk                  = "1.13.12"
 bcv                    = "0.16.3"
+kover                  = "0.8.3"
 
 [libraries]
 androidx-core-ktx              = { module = "androidx.core:core-ktx",                          version.ref = "core-ktx" }
@@ -47,3 +48,4 @@ kotlin-android         = { id = "org.jetbrains.kotlin.android",        version.r
 detekt                 = { id = "io.gitlab.arturbosch.detekt",         version.ref = "detekt" }
 vanniktech-publish     = { id = "com.vanniktech.maven.publish",        version.ref = "vanniktech-publish" }
 bcv                    = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "bcv" }
+kover                  = { id = "org.jetbrains.kotlinx.kover",                          version.ref = "kover" }


### PR DESCRIPTION
## Summary

- Adds Kotlinx Kover (0.8.3) to `TopsortAnalytics`
- `koverVerify` enforces a minimum **35% line coverage** on every PR (excludes `BuildConfig` and `WorkManager` glue classes)
- `tests.yaml` generates an HTML coverage report and uploads it as a workflow artifact (retained 14 days)

## Coverage threshold rationale

The new unit tests in PR-0 (#37) bring JVM coverage to ~35-45%.
Starting at 35% is conservative enough not to fail immediately while still catching regressions.
Raise `minBound` incrementally as more tests are added.

Excluded from coverage:
- `com.topsort.analytics.BuildConfig` — generated class
- `com.topsort.analytics.worker` — WorkManager glue; only testable via instrumented tests

## Stacks on: #42 (BCV)
Depends on #37 (unit tests) already being merged so the threshold is met.

## Test plan
- [ ] `./gradlew :TopsortAnalytics:koverVerify` passes
- [ ] Coverage report artifact appears on the workflow run