### PR TITLE
docs: add Dokka API documentation published to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,47 @@
+name: Publish Docs
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build-docs:
+    name: Build Docs
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - uses: gradle/actions/setup-gradle@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d  # v4
+
+      - run: ./gradlew :TopsortAnalytics:dokkaHtml
+
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3
+        with:
+          path: TopsortAnalytics/build/dokka/html/
+
+  deploy-docs:
+    name: Deploy Docs
+    needs: build-docs
+    runs-on: ubuntu-22.04
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,6 +32,17 @@ jobs:
       - name: Run unit tests
         run: ./gradlew :TopsortAnalytics:test
 
+      - name: Generate coverage report
+        run: ./gradlew :TopsortAnalytics:koverHtmlReport :TopsortAnalytics:koverVerify
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        if: always()
+        with:
+          name: coverage-report
+          path: TopsortAnalytics/build/reports/kover/html/
+          retention-days: 14
+
       - name: Publish unit test results
         uses: mikepenz/action-junit-report@db71d41eb79864e25ab0337e395c352e84523afe  # v4
         if: always()

--- a/TopsortAnalytics/api/TopsortAnalytics.api
+++ b/TopsortAnalytics/api/TopsortAnalytics.api
@@ -783,4 +783,3 @@ public final class com/topsort/analytics/service/TopsortAuctionsHttpService : co
 	public final fun setMockService (Lcom/topsort/analytics/service/AuctionsHttpService;)V
 	public final fun setServiceInstance (Lcom/topsort/analytics/service/AuctionsHttpService;)V
 }
-

--- a/TopsortAnalytics/build.gradle
+++ b/TopsortAnalytics/build.gradle
@@ -6,6 +6,8 @@ plugins {
     alias(libs.plugins.detekt)
     alias(libs.plugins.vanniktech.publish)
     alias(libs.plugins.bcv)
+    alias(libs.plugins.kover)
+    alias(libs.plugins.dokka)
 }
 
 android {
@@ -45,6 +47,39 @@ kotlin {
 
 tasks.withType(Detekt).configureEach {
     config = files(["$projectDir/../detekt.yaml"])
+}
+
+kover {
+    reports {
+        verify {
+            rule {
+                minBound(35)
+            }
+        }
+        filters {
+            excludes {
+                classes("com.topsort.analytics.BuildConfig")
+                classes("com.topsort.analytics.EventPipeline\$EventEmitterWorker")
+                packages("com.topsort.analytics.worker")
+            }
+        }
+    }
+}
+
+tasks.named('dokkaHtml') {
+    outputDirectory = layout.buildDirectory.dir('dokka/html')
+    dokkaSourceSets {
+        named('main') {
+            moduleName = 'Topsort Analytics'
+            includeNonPublic = false
+            skipEmptyPackages = true
+            sourceLink {
+                localDirectory = file("src/main/java")
+                remoteUrl = new URL("https://github.com/Topsort/topsort.kt/blob/main/TopsortAnalytics/src/main/java")
+                remoteLineSuffix = "#L"
+            }
+        }
+    }
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,8 @@ plugins {
     alias(libs.plugins.detekt)              apply false
     alias(libs.plugins.vanniktech.publish)  apply false
     alias(libs.plugins.bcv)                 apply false
+    alias(libs.plugins.kover)               apply false
+    alias(libs.plugins.dokka)               apply false
 }
 
 subprojects {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,8 @@ espresso               = "3.6.1"
 kotlinx-coroutines     = "1.7.3"
 mockk                  = "1.13.12"
 bcv                    = "0.16.3"
+kover                  = "0.8.3"
+dokka                  = "1.9.20"
 
 [libraries]
 androidx-core-ktx              = { module = "androidx.core:core-ktx",                          version.ref = "core-ktx" }
@@ -47,3 +49,5 @@ kotlin-android         = { id = "org.jetbrains.kotlin.android",        version.r
 detekt                 = { id = "io.gitlab.arturbosch.detekt",         version.ref = "detekt" }
 vanniktech-publish     = { id = "com.vanniktech.maven.publish",        version.ref = "vanniktech-publish" }
 bcv                    = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "bcv" }
+kover                  = { id = "org.jetbrains.kotlinx.kover",                          version.ref = "kover" }
+dokka                  = { id = "org.jetbrains.dokka",                                  version.ref = "dokka" }


### PR DESCRIPTION
## Summary

- Adds Dokka (1.9.20) to `TopsortAnalytics` with source links pointing to GitHub blob view
- New `.github/workflows/docs.yaml` builds `dokkaHtml` on every push to `main` and deploys to GitHub Pages

## One-time repo setup required

In GitHub **Settings > Pages**, set Source to **"GitHub Actions"** (not a branch).

After that, docs will be published automatically on every merge to `main`.

## Stacks on: #43 (Kover)

## Test plan
- [ ] `./gradlew :TopsortAnalytics:dokkaHtml` completes locally
- [ ] Enable GitHub Pages and merge to main; verify docs site is live