### PR TITLE
docs: add Dokka API documentation published to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,46 @@
+name: Publish Docs
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build-docs:
+    name: Build Docs
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - uses: gradle/actions/setup-gradle@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d  # v4
+
+      - name: Generate Dokka HTML
+        run: ./gradlew :TopsortAnalytics:dokkaHtml
+
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3
+        with:
+          path: TopsortAnalytics/build/dokka/html/
+
+  deploy-docs:
+    name: Deploy Docs to GitHub Pages
+    needs: build-docs
+    runs-on: ubuntu-22.04
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4

--- a/TopsortAnalytics/build.gradle
+++ b/TopsortAnalytics/build.gradle
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.vanniktech.publish)
     alias(libs.plugins.bcv)
     alias(libs.plugins.kover)
+    alias(libs.plugins.dokka)
 }
 
 android {
@@ -60,6 +61,22 @@ kover {
                 classes("com.topsort.analytics.BuildConfig")
                 classes("com.topsort.analytics.EventPipeline\$EventEmitterWorker")
                 packages("com.topsort.analytics.worker")
+            }
+        }
+    }
+}
+
+tasks.named('dokkaHtml') {
+    outputDirectory = layout.buildDirectory.dir('dokka/html')
+    dokkaSourceSets {
+        named('main') {
+            moduleName = 'Topsort Analytics'
+            includeNonPublic = false
+            skipEmptyPackages = true
+            sourceLink {
+                localDirectory = file("src/main/java")
+                remoteUrl = new URL("https://github.com/Topsort/topsort.kt/blob/main/TopsortAnalytics/src/main/java")
+                remoteLineSuffix = "#L"
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ plugins {
     alias(libs.plugins.vanniktech.publish)  apply false
     alias(libs.plugins.bcv)                 apply false
     alias(libs.plugins.kover)               apply false
+    alias(libs.plugins.dokka)               apply false
 }
 
 subprojects {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ kotlinx-coroutines     = "1.7.3"
 mockk                  = "1.13.12"
 bcv                    = "0.16.3"
 kover                  = "0.8.3"
+dokka                  = "1.9.20"
 
 [libraries]
 androidx-core-ktx              = { module = "androidx.core:core-ktx",                          version.ref = "core-ktx" }
@@ -49,3 +50,4 @@ detekt                 = { id = "io.gitlab.arturbosch.detekt",         version.r
 vanniktech-publish     = { id = "com.vanniktech.maven.publish",        version.ref = "vanniktech-publish" }
 bcv                    = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "bcv" }
 kover                  = { id = "org.jetbrains.kotlinx.kover",                          version.ref = "kover" }
+dokka                  = { id = "org.jetbrains.dokka",                                  version.ref = "dokka" }


### PR DESCRIPTION
## Summary

- Adds Dokka plugin (`org.jetbrains.dokka:1.9.20`) via version catalog
- Configures `dokkaHtml` task in `:TopsortAnalytics` with source links to GitHub
- Adds `.github/workflows/docs.yaml` to build and publish Dokka HTML to GitHub Pages on every push to `main`

## Test plan

- [x] `./gradlew :TopsortAnalytics:dokkaHtml` generates HTML output in `TopsortAnalytics/build/dokka/html/`
- [x] Detekt passes
- [x] Unit and instrumented tests pass
- [ ] After merge, enable GitHub Pages in repo Settings → Pages → Source: GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)