### PR TITLE
fix: prevent NPE crashes in event reporting and banner auctions

### DIFF
--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/Analytics.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/Analytics.kt
@@ -68,6 +68,11 @@ object Analytics : TopsortAnalytics {
         id: String?,
         occurredAt: String?,
     ) {
+        if (!assertSetup()) {
+            Log.e(LOG_TAG, INVALID_CONFIG_ERROR_MESSAGE)
+            return
+        }
+
         val impressions = listOf(
             Impression.Factory.buildPromoted(
                 resolvedBidId = resolvedBidId,
@@ -88,6 +93,11 @@ object Analytics : TopsortAnalytics {
         id: String?,
         occurredAt: String?,
     ) {
+        if (!assertSetup()) {
+            Log.e(LOG_TAG, INVALID_CONFIG_ERROR_MESSAGE)
+            return
+        }
+
         val impressions = listOf(
             Impression.Factory.buildOrganic(
                 entity = entity,
@@ -108,6 +118,11 @@ object Analytics : TopsortAnalytics {
         id: String?,
         occurredAt: String?,
     ) {
+        if (!assertSetup()) {
+            Log.e(LOG_TAG, INVALID_CONFIG_ERROR_MESSAGE)
+            return
+        }
+
         val clicks = listOf(
             Click.Factory.buildPromoted(
                 resolvedBidId = resolvedBidId,
@@ -128,6 +143,11 @@ object Analytics : TopsortAnalytics {
         id: String?,
         occurredAt: String?,
     ) {
+        if (!assertSetup()) {
+            Log.e(LOG_TAG, INVALID_CONFIG_ERROR_MESSAGE)
+            return
+        }
+
         val clicks = listOf(
             Click.Factory.buildOrganic(
                 entity = entity,
@@ -196,7 +216,12 @@ object Analytics : TopsortAnalytics {
             .setConstraints(constraints)
 
 
-        val continuation = workManager!!
+        val wm = workManager ?: run {
+            Log.e(LOG_TAG, INVALID_CONFIG_ERROR_MESSAGE)
+            return
+        }
+
+        val continuation = wm
             .beginUniqueWork(
                 EventEmitterWorker.WORK_NAME,
                 ExistingWorkPolicy.APPEND,

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/EventPipeline.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/EventPipeline.kt
@@ -85,8 +85,12 @@ internal object EventPipeline {
         val requestBuilder = OneTimeWorkRequestBuilder<EventEmitterWorker>()
             .setConstraints(constraints)
 
-        workManager!!
-            .enqueueUniqueWork(
+        val wm = workManager ?: run {
+            Logger.log.add("EventPipeline: workManager not initialized, skipping upload")
+            return
+        }
+
+        wm.enqueueUniqueWork(
                 UPLOAD_SIGNAL,
                 ExistingWorkPolicy.REPLACE,
                 requestBuilder.build()

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/banners/run.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/banners/run.kt
@@ -38,9 +38,10 @@ suspend fun runBannerAuction(config: BannerConfig): BannerResponse? {
             // Check if there are any results with winners
             if (response.results.isNotEmpty() && response.results[0].winners.isNotEmpty()) {
                 val winner = response.results[0].winners[0]
+                val assetUrl = winner.asset?.firstOrNull()?.url ?: return null
                 return BannerResponse(
                     id = winner.id,
-                    url = winner.asset!![0].url,
+                    url = assetUrl,
                     type = winner.type,
                     resolvedBidId = winner.resolvedBidId
                 )

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/model/Placement.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/model/Placement.kt
@@ -64,7 +64,7 @@ data class Placement(
             .put("page", page)
             .put("pageSize", pageSize)
             .put("productId", productId)
-            .put("categoryIds", JSONArray(categoryIds))
+            .put("categoryIds", categoryIds?.let { JSONArray(it) })
             .put("searchQuery", searchQuery)
             .put("location", location)
     }

--- a/TopsortAnalytics/src/test/java/com/topsort/analytics/JsonTest.kt
+++ b/TopsortAnalytics/src/test/java/com/topsort/analytics/JsonTest.kt
@@ -2,6 +2,7 @@ package com.topsort.analytics
 
 import com.topsort.analytics.model.Click
 import com.topsort.analytics.model.Impression
+import com.topsort.analytics.model.Placement
 import com.topsort.analytics.model.Purchase
 import org.json.JSONObject
 import org.junit.Test
@@ -49,5 +50,83 @@ internal class JsonTest {
 
         assertThat(purchase).isNotSameAs(deserialized)
         assertThat(purchase).isEqualTo(deserialized)
+    }
+
+    @Test
+    fun `placement toJsonObject with null categoryIds does not crash`() {
+        val placement = Placement(
+            path = "test/path",
+            categoryIds = null,
+        )
+
+        val json = placement.toJsonObject()
+
+        assertThat(json.getString("path")).isEqualTo("test/path")
+        assertThat(json.isNull("categoryIds")).isTrue()
+    }
+
+    @Test
+    fun `placement toJsonObject with categoryIds serializes array`() {
+        val placement = Placement(
+            path = "test/path",
+            categoryIds = listOf("cat1", "cat2"),
+        )
+
+        val json = placement.toJsonObject()
+
+        assertThat(json.getString("path")).isEqualTo("test/path")
+        val categoryArray = json.getJSONArray("categoryIds")
+        assertThat(categoryArray.length()).isEqualTo(2)
+        assertThat(categoryArray.getString(0)).isEqualTo("cat1")
+        assertThat(categoryArray.getString(1)).isEqualTo("cat2")
+    }
+
+    @Test
+    fun `placement roundtrip with all optional fields null`() {
+        val placement = Placement(path = "minimal/path")
+
+        val serialized = placement.toJsonObject().toString()
+        val deserialized = Placement.fromJsonObject(JSONObject(serialized))
+
+        assertThat(deserialized.path).isEqualTo("minimal/path")
+        assertThat(deserialized.position).isNull()
+        assertThat(deserialized.page).isNull()
+        assertThat(deserialized.pageSize).isNull()
+        assertThat(deserialized.productId).isNull()
+        assertThat(deserialized.categoryIds).isNull()
+        assertThat(deserialized.searchQuery).isNull()
+        assertThat(deserialized.location).isNull()
+    }
+
+    @Test
+    fun `placement roundtrip with all fields populated`() {
+        val placement = Placement(
+            path = "full/path",
+            position = 3,
+            page = 2,
+            pageSize = 10,
+            productId = "prod-1",
+            categoryIds = listOf("cat-a", "cat-b"),
+            searchQuery = "shoes",
+            location = "top-banner",
+        )
+
+        val serialized = placement.toJsonObject().toString()
+        val deserialized = Placement.fromJsonObject(JSONObject(serialized))
+
+        assertThat(deserialized).isEqualTo(placement)
+    }
+
+    @Test
+    fun `placement build factory with null categoryIds`() {
+        val placement = Placement.build(
+            path = "factory/path",
+            categoryIds = null,
+        )
+
+        val json = placement.toJsonObject()
+
+        assertThat(json.getString("path")).isEqualTo("factory/path")
+        assertThat(json.isNull("categoryIds")).isTrue()
     }
 }


### PR DESCRIPTION
## Summary
- Add `assertSetup()` guard to all 4 individual report methods (`reportImpressionPromoted`, `reportImpressionOrganic`, `reportClickPromoted`, `reportClickOrganic`) — previously crashed with NPE if called before `setup()`
- Guard `workManager!!` accesses in `Analytics.enqueueEventRequest()` and `EventPipeline.upload()` with safe null-check fallbacks
- Fix `winner.asset!![0].url` crash in `runBannerAuction()` — use null-safe `firstOrNull()` to handle winners without assets
- Fix `JSONArray(categoryIds)` NPE in `Placement.toJsonObject()` when `categoryIds` is null

## Test plan
- [x] `./gradlew :TopsortAnalytics:test` — all unit tests pass
- [x] `./gradlew detekt` — no style violations
- [x] `./gradlew :TopsortAnalytics:apiCheck` — no API surface changes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)