### PR TITLE
fix: send events on any network and retry on transient failures

### DIFF
--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/Analytics.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/Analytics.kt
@@ -206,7 +206,7 @@ object Analytics : TopsortAnalytics {
             .build()
 
         val constraints = Constraints.Builder()
-            .setRequiredNetworkType(NetworkType.UNMETERED)
+            .setRequiredNetworkType(NetworkType.CONNECTED)
             .setRequiresBatteryNotLow(false)
             .setRequiresDeviceIdle(false)
             .build()

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/worker/EventEmitterWorker.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/worker/EventEmitterWorker.kt
@@ -44,7 +44,7 @@ internal class EventEmitterWorker(
                     Cache.deleteEvent(recordId)
                     Result.success()
                 } else {
-                    Result.failure()
+                    Result.retry()
                 }
             }
             EventType.Click -> {
@@ -53,7 +53,7 @@ internal class EventEmitterWorker(
                     Cache.deleteEvent(recordId)
                     Result.success()
                 } else {
-                    Result.failure()
+                    Result.retry()
                 }
             }
             EventType.Purchase -> {
@@ -62,7 +62,7 @@ internal class EventEmitterWorker(
                     Cache.deleteEvent(recordId)
                     Result.success()
                 } else {
-                    Result.failure()
+                    Result.retry()
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Change `NetworkType.UNMETERED` → `NetworkType.CONNECTED` in `Analytics.kt` so events deliver on mobile data, not just WiFi. The WiFi-only constraint caused events to queue indefinitely for users on cellular connections — catastrophic for a mobile SDK.
- Change `Result.failure()` → `Result.retry()` in `EventEmitterWorker` so WorkManager retries with exponential backoff (30s initial) on transient network errors, instead of permanently discarding events.

## Test plan
- [x] `./gradlew :TopsortAnalytics:test` — all unit tests pass
- [x] `./gradlew detekt` — no style violations
- [x] `./gradlew :TopsortAnalytics:apiCheck` — no API surface changes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)