### PR TITLE
fix: close HTTP connections on success and fix READ_TIMEOUT typo

### DIFF
--- a/TopsortAnalytics/api/TopsortAnalytics.api
+++ b/TopsortAnalytics/api/TopsortAnalytics.api
@@ -217,7 +217,7 @@ public final class com/topsort/analytics/core/RandomGeneratorKt {
 public final class com/topsort/analytics/core/RequestFactory {
 	public static final field CONNECTION_TIMEOUT I
 	public static final field Companion Lcom/topsort/analytics/core/RequestFactory$Companion;
-	public static final field READ_TIMETOUT I
+	public static final field READ_TIMEOUT I
 	public fun <init> ()V
 	public final fun upload (Ljava/lang/String;Ljava/lang/String;)Ljava/net/HttpURLConnection;
 }

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/core/HttpClient.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/core/HttpClient.kt
@@ -31,27 +31,30 @@ class HttpClient (
     fun post(body: String, bearerToken: String?): HttpResponse {
         val connection: HttpURLConnection = requestFactory.upload(apiHost, bearerToken)
         val postConnection = connection.createPostConnection()
-        val writeStream = postConnection.outputStream!!.bufferedWriter()
+        try {
+            val writeStream = postConnection.outputStream!!.bufferedWriter()
 
-        writeStream.write(body)
-        writeStream.flush()
-        postConnection.outputStream.close()
+            writeStream.write(body)
+            writeStream.flush()
+            postConnection.outputStream.close()
 
-        @Suppress("detekt:MagicNumber")
-        if (connection.responseCode !in 200..299) {
-            postConnection.close()
-            return HttpResponse(connection.responseCode, connection.responseMessage)
-        }
-
-        val inputStream =
-            try {
-                connection.inputStream
-            } catch (ignored: IOException) {
-                connection.errorStream
+            @Suppress("detekt:MagicNumber")
+            if (connection.responseCode !in 200..299) {
+                return HttpResponse(connection.responseCode, connection.responseMessage)
             }
 
-        val responseBody = inputStream?.bufferedReader()?.use(BufferedReader::readText)
-        return HttpResponse(connection.responseCode, connection.responseMessage, responseBody)
+            val inputStream =
+                try {
+                    connection.inputStream
+                } catch (ignored: IOException) {
+                    connection.errorStream
+                }
+
+            val responseBody = inputStream?.bufferedReader()?.use(BufferedReader::readText)
+            return HttpResponse(connection.responseCode, connection.responseMessage, responseBody)
+        } finally {
+            postConnection.close()
+        }
     }
 }
 
@@ -114,12 +117,12 @@ class RequestFactory {
         }
         val connection = requestedURL.openConnection() as HttpURLConnection
         connection.connectTimeout = CONNECTION_TIMEOUT
-        connection.readTimeout = READ_TIMETOUT
+        connection.readTimeout = READ_TIMEOUT
         return connection
     }
 
     companion object {
         const val CONNECTION_TIMEOUT = 15_000 // 15 seconds
-        const val READ_TIMETOUT = 20_000 // 20 seconds
+        const val READ_TIMEOUT = 20_000 // 20 seconds
     }
 }


### PR DESCRIPTION
## Summary
- Wrap `HttpClient.post()` in try/finally to always close the connection — previously only error paths called `close()`, leaking connections on every successful request
- Fix `READ_TIMETOUT` → `READ_TIMEOUT` typo in `RequestFactory.Companion` (public API rename via `apiDump`)

## Test plan
- [x] `./gradlew :TopsortAnalytics:test` — all unit tests pass
- [x] `./gradlew detekt` — no style violations
- [x] `./gradlew :TopsortAnalytics:apiCheck` — API dump updated for typo rename
- [ ] CI passes

**Note:** This includes a public API rename (`READ_TIMETOUT` → `READ_TIMEOUT`). This is a breaking change for any consumers referencing the constant directly, but the previous name was a typo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)