### PR TITLE
fix: prevent race condition in Cache.nextRecordKey()

### DIFF
--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/Cache.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/Cache.kt
@@ -130,6 +130,7 @@ internal object Cache {
         recordId
     )
 
+    @Synchronized
     private fun nextRecordKey(): String {
         recentRecordId = if (recentRecordId < Long.MAX_VALUE) {
             recentRecordId + 1
@@ -140,7 +141,7 @@ internal object Cache {
         preferences
             .edit()
             .putLong(KEY_RECENT_RECORD_ID, recentRecordId)
-            .apply()
+            .commit()
         return recordKey(recentRecordId)
     }
 }


### PR DESCRIPTION
## Summary
- Add `@Synchronized` to `nextRecordKey()` to prevent concurrent calls from getting the same `recentRecordId`, which would cause one event to overwrite another
- Switch from `apply()` to `commit()` for the record ID write to ensure ordering — the ID must be persisted synchronously so subsequent calls see the updated value

## Test plan
- [x] `./gradlew :TopsortAnalytics:test` — all unit tests pass
- [x] `./gradlew detekt` — no style violations
- [x] `./gradlew :TopsortAnalytics:apiCheck` — no API surface changes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)