### PR TITLE
docs: add CODEOWNERS targeting code files only

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Source code
+*.kt @Topsort/integrations
+*.kts @Topsort/integrations
+
+# Build config
+*.gradle @Topsort/integrations
+
+# CI
+.github/ @Topsort/integrations


### PR DESCRIPTION
## Summary
- Add CODEOWNERS with targeted patterns for source code (*.kt, *.kts), build config (*.gradle), and CI (.github/)
- Docs-only PRs (*.md, LICENSE) don't require integrations team review

## Test plan
- [ ] Verify CODEOWNERS syntax is valid on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)