### PR TITLE
fix: use **/ prefix in CODEOWNERS for recursive matching

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,9 @@
 # Source code
-*.kt @Topsort/integrations
-*.kts @Topsort/integrations
+**/*.kt @Topsort/integrations
+**/*.kts @Topsort/integrations
 
 # Build config
-*.gradle @Topsort/integrations
+**/*.gradle @Topsort/integrations
 
 # CI
 .github/ @Topsort/integrations


### PR DESCRIPTION
## Summary
- Fix CODEOWNERS glob patterns to use `**/` prefix for recursive subdirectory matching
- Without `**/`, patterns like `*.kt` may only match root-level files per CODEOWNERS spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)