### PR TITLE
docs: document unitPrice currency unit and clarify README version

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Simply add the dependency to your build.gradle file:
 dependencies {
     ...
 
+    // Check Maven Central for the latest version:
+    // https://central.sonatype.com/artifact/com.topsort/topsort-kt
     implementation 'com.topsort:topsort-kt:2.0.0'
 }
 ```
@@ -175,7 +177,7 @@ fun reportPurchase() {
     val item = PurchasedItem(
         productId = "productId",
         quantity = 20,
-        unitPrice = 1295,
+        unitPrice = 1295, // price in cents ($12.95)
         resolvedBidId = "<The bid id from the auction winner>"
     )
 

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/model/PurchaseEvent.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/model/PurchaseEvent.kt
@@ -92,6 +92,11 @@ data class PurchasedItem(
     val productId: String,
 
     @IntRange(from = 1) val quantity: Int,
+
+    /**
+     * Unit price in the smallest currency unit (e.g., cents for USD).
+     * Example: 1295 = $12.95
+     */
     @IntRange(from = 1) val unitPrice: Int? = null,
 
     /**


### PR DESCRIPTION
## Summary
- Add KDoc to `PurchasedItem.unitPrice` clarifying the value is in the smallest currency unit (e.g., cents for USD: 1295 = $12.95)
- Add inline comment to README purchase example showing the cents convention
- Add note in README directing users to Maven Central for the latest version instead of relying on the hardcoded `2.0.0`

## Context
The unitPrice field uses an integer representing the smallest currency unit, but this was undocumented. Without this context, consumers could easily pass dollar amounts instead of cents, causing silent 100x data corruption in purchase reporting.

## Test plan
- [ ] Verify KDoc renders correctly in IDE
- [ ] Verify README formatting looks correct on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)