### PR TITLE
fix: add error logging in EventEmitterWorker

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Simply add the dependency to your build.gradle file:
 dependencies {
     ...
 
+    // Check Maven Central for the latest version:
+    // https://central.sonatype.com/artifact/com.topsort/topsort-kt
     implementation 'com.topsort:topsort-kt:2.0.0'
 }
 ```
@@ -175,7 +177,7 @@ fun reportPurchase() {
     val item = PurchasedItem(
         productId = "productId",
         quantity = 20,
-        unitPrice = 1295,
+        unitPrice = 1295, // price in cents ($12.95)
         resolvedBidId = "<The bid id from the auction winner>"
     )
 

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/model/PurchaseEvent.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/model/PurchaseEvent.kt
@@ -92,6 +92,11 @@ data class PurchasedItem(
     val productId: String,
 
     @IntRange(from = 1) val quantity: Int,
+
+    /**
+     * Unit price in the smallest currency unit (e.g., cents for USD).
+     * Example: 1295 = $12.95
+     */
     @IntRange(from = 1) val unitPrice: Int? = null,
 
     /**

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/worker/EventEmitterWorker.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/worker/EventEmitterWorker.kt
@@ -1,6 +1,7 @@
 package com.topsort.analytics.worker
 
 import android.content.Context
+import android.util.Log
 import androidx.work.Worker
 import androidx.work.WorkerParameters
 import com.topsort.analytics.Cache
@@ -71,8 +72,12 @@ internal class EventEmitterWorker(
     private fun reportImpression(impressionEvent: ImpressionEvent): Boolean {
         return try {
             val response = TopsortAnalyticsHttpService.service.reportImpression(impressionEvent)
+            if (!response.isSuccessful()) {
+                Log.e(TAG, "Failed to report impression: ${response.code} ${response.message}")
+            }
             response.isSuccessful()
-        } catch (ignored: Exception) {
+        } catch (e: Exception) {
+            Log.e(TAG, "Exception reporting impression", e)
             false
         }
     }
@@ -80,8 +85,12 @@ internal class EventEmitterWorker(
     private fun reportClick(clickEvent: ClickEvent): Boolean {
         return try {
             val response = TopsortAnalyticsHttpService.service.reportClick(clickEvent)
+            if (!response.isSuccessful()) {
+                Log.e(TAG, "Failed to report click: ${response.code} ${response.message}")
+            }
             response.isSuccessful()
-        } catch (ignored: Exception) {
+        } catch (e: Exception) {
+            Log.e(TAG, "Exception reporting click", e)
             false
         }
     }
@@ -89,13 +98,19 @@ internal class EventEmitterWorker(
     private fun reportPurchase(purchaseEvent: PurchaseEvent): Boolean {
         return try {
             val response = TopsortAnalyticsHttpService.service.reportPurchase(purchaseEvent)
+            if (!response.isSuccessful()) {
+                Log.e(TAG, "Failed to report purchase: ${response.code} ${response.message}")
+            }
             response.isSuccessful()
-        } catch (ignored: Exception) {
+        } catch (e: Exception) {
+            Log.e(TAG, "Exception reporting purchase", e)
             false
         }
     }
 
     companion object {
+        private const val TAG = "TopsortEventEmitter"
+
         const val EXTRA_RECORD_ID = "EXTRA_RECORD_ID"
         const val EXTRA_EVENT_TYPE = "EXTRA_EVENT_TYPE"
 


### PR DESCRIPTION
## Summary
- Replace silent exception swallowing in `EventEmitterWorker`'s `reportImpression()`, `reportClick()`, and `reportPurchase()` with `Log.e` calls
- Log HTTP status code and message for failed (non-2xx) responses
- Log full stack trace for caught exceptions
- Add `TAG` companion constant for consistent log filtering

## Context
The production event pipeline (`Cache → EventEmitterWorker → HTTP`) silently swallowed all errors — failed HTTP responses and network exceptions both returned `false` without any logging. This made it impossible to diagnose event delivery failures in production. This change is logging-only and does not alter retry behavior.

## Stack
- Based on: #88

## Test plan
- [ ] Unit tests pass (`./gradlew :TopsortAnalytics:test`)
- [ ] Detekt passes
- [ ] apiCheck passes (no public API changes)
- [ ] Verify logs appear in logcat when HTTP service returns error responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)