### PR TITLE
fix: lower jvmTarget to 11 for broader consumer compatibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ Package layout:
 
 ## Code Conventions
 
-- Kotlin, Java 17 source/target, JVM toolchain 17.
+- Kotlin, Java 11 source/target, JVM toolchain 17 (build requires JDK 17, bytecode targets JVM 11).
 - Detekt enforces style (config: `detekt.yaml`). Run before pushing.
 - RFC3339 timestamps via Joda-Time (`eventNow()` helper in `EventTimestamp.kt`).
 - `JsonSerializable` interface for all models that go over the wire.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Licensed under [MIT][1].
 
 ## Requirements
 
-- Minimum Java version: 17
+- Minimum Java version: 11
 - Android SDK: 24+
 - `INTERNET` permission (add to your `AndroidManifest.xml` if not already present)
 
@@ -25,17 +25,17 @@ dependencies {
 }
 ```
 
-Ensure your project is configured to use Java 17:
+Ensure your project is configured to use at least Java 11:
 
 ```gradle
 android {
     // Other configurations...
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = '17'
+        jvmTarget = '11'
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Simply add the dependency to your build.gradle file:
 dependencies {
     ...
 
+    // Check Maven Central for the latest version:
+    // https://central.sonatype.com/artifact/com.topsort/topsort-kt
     implementation 'com.topsort:topsort-kt:2.0.0'
 }
 ```
@@ -175,7 +177,7 @@ fun reportPurchase() {
     val item = PurchasedItem(
         productId = "productId",
         quantity = 20,
-        unitPrice = 1295,
+        unitPrice = 1295, // price in cents ($12.95)
         resolvedBidId = "<The bid id from the auction winner>"
     )
 

--- a/TopsortAnalytics/build.gradle
+++ b/TopsortAnalytics/build.gradle
@@ -33,11 +33,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = '17'
+        jvmTarget = '11'
     }
 }
 

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/model/PurchaseEvent.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/model/PurchaseEvent.kt
@@ -92,6 +92,11 @@ data class PurchasedItem(
     val productId: String,
 
     @IntRange(from = 1) val quantity: Int,
+
+    /**
+     * Unit price in the smallest currency unit (e.g., cents for USD).
+     * Example: 1295 = $12.95
+     */
     @IntRange(from = 1) val unitPrice: Int? = null,
 
     /**

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/worker/EventEmitterWorker.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/worker/EventEmitterWorker.kt
@@ -1,6 +1,7 @@
 package com.topsort.analytics.worker
 
 import android.content.Context
+import android.util.Log
 import androidx.work.Worker
 import androidx.work.WorkerParameters
 import com.topsort.analytics.Cache
@@ -71,8 +72,12 @@ internal class EventEmitterWorker(
     private fun reportImpression(impressionEvent: ImpressionEvent): Boolean {
         return try {
             val response = TopsortAnalyticsHttpService.service.reportImpression(impressionEvent)
+            if (!response.isSuccessful()) {
+                Log.e(TAG, "Failed to report impression: ${response.code} ${response.message}")
+            }
             response.isSuccessful()
-        } catch (ignored: Exception) {
+        } catch (e: Exception) {
+            Log.e(TAG, "Exception reporting impression", e)
             false
         }
     }
@@ -80,8 +85,12 @@ internal class EventEmitterWorker(
     private fun reportClick(clickEvent: ClickEvent): Boolean {
         return try {
             val response = TopsortAnalyticsHttpService.service.reportClick(clickEvent)
+            if (!response.isSuccessful()) {
+                Log.e(TAG, "Failed to report click: ${response.code} ${response.message}")
+            }
             response.isSuccessful()
-        } catch (ignored: Exception) {
+        } catch (e: Exception) {
+            Log.e(TAG, "Exception reporting click", e)
             false
         }
     }
@@ -89,13 +98,19 @@ internal class EventEmitterWorker(
     private fun reportPurchase(purchaseEvent: PurchaseEvent): Boolean {
         return try {
             val response = TopsortAnalyticsHttpService.service.reportPurchase(purchaseEvent)
+            if (!response.isSuccessful()) {
+                Log.e(TAG, "Failed to report purchase: ${response.code} ${response.message}")
+            }
             response.isSuccessful()
-        } catch (ignored: Exception) {
+        } catch (e: Exception) {
+            Log.e(TAG, "Exception reporting purchase", e)
             false
         }
     }
 
     companion object {
+        private const val TAG = "TopsortEventEmitter"
+
         const val EXTRA_RECORD_ID = "EXTRA_RECORD_ID"
         const val EXTRA_EVENT_TYPE = "EXTRA_EVENT_TYPE"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,11 +36,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = '17'
+        jvmTarget = '11'
     }
     buildFeatures {
         buildConfig = true

--- a/build.gradle
+++ b/build.gradle
@@ -15,11 +15,11 @@ plugins {
 
 subprojects {
     tasks.withType(Detekt).configureEach {
-        jvmTarget = '17'
+        jvmTarget = '11'
         autoCorrect = true
         buildUponDefaultConfig = true
     }
     tasks.withType(DetektCreateBaselineTask).configureEach {
-        jvmTarget = '17'
+        jvmTarget = '11'
     }
 }


### PR DESCRIPTION
## Summary
- Lower bytecode target from JVM 17 to JVM 11 in the library, sample app, and detekt config
- Update README to reflect new minimum Java 11 requirement for consumers
- Update CLAUDE.md code conventions to clarify the build/target distinction

## Context
The SDK uses zero JDK 17 language features. Lowering the bytecode target to JVM 11 allows apps that target JDK 11 to depend on `topsort-kt` without `UnsupportedClassVersionError`. The **build toolchain** remains JDK 17 (required by AGP 8.5.1 and Gradle 9.3.1) — only the emitted class file version changes.

## Files changed
- `TopsortAnalytics/build.gradle` — `VERSION_17` → `VERSION_11`, `jvmTarget '17'` → `'11'`
- `app/build.gradle` — same
- `build.gradle` (root) — detekt `jvmTarget '17'` → `'11'`
- `README.md` — minimum Java 17 → 11, `compileOptions` example updated
- `CLAUDE.md` — code conventions updated

## Stack
- Based on: #89

## Test plan
- [x] Unit tests pass (`./gradlew :TopsortAnalytics:test`)
- [x] Detekt passes
- [x] apiCheck passes (no public API surface change — jvmTarget only affects bytecode version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)