### PR TITLE
refactor: make internal classes internal and update API surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ Package layout:
 
 ## Code Conventions
 
-- Kotlin, Java 17 source/target, JVM toolchain 17.
+- Kotlin, Java 11 source/target, JVM toolchain 17 (build requires JDK 17, bytecode targets JVM 11).
 - Detekt enforces style (config: `detekt.yaml`). Run before pushing.
 - RFC3339 timestamps via Joda-Time (`eventNow()` helper in `EventTimestamp.kt`).
 - `JsonSerializable` interface for all models that go over the wire.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Licensed under [MIT][1].
 
 ## Requirements
 
-- Minimum Java version: 17
+- Minimum Java version: 11
 - Android SDK: 24+
 - `INTERNET` permission (add to your `AndroidManifest.xml` if not already present)
 
@@ -25,17 +25,17 @@ dependencies {
 }
 ```
 
-Ensure your project is configured to use Java 17:
+Ensure your project is configured to use at least Java 11:
 
 ```gradle
 android {
     // Other configurations...
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = '17'
+        jvmTarget = '11'
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Simply add the dependency to your build.gradle file:
 dependencies {
     ...
 
+    // Check Maven Central for the latest version:
+    // https://central.sonatype.com/artifact/com.topsort/topsort-kt
     implementation 'com.topsort:topsort-kt:2.0.0'
 }
 ```
@@ -175,7 +177,7 @@ fun reportPurchase() {
     val item = PurchasedItem(
         productId = "productId",
         quantity = 20,
-        unitPrice = 1295,
+        unitPrice = 1295, // price in cents ($12.95)
         resolvedBidId = "<The bid id from the auction winner>"
     )
 

--- a/TopsortAnalytics/api/TopsortAnalytics.api
+++ b/TopsortAnalytics/api/TopsortAnalytics.api
@@ -9,11 +9,6 @@ public final class com/topsort/analytics/Analytics : com/topsort/analytics/Topso
 	public final fun setup (Landroid/app/Application;Ljava/lang/String;Ljava/lang/String;)V
 }
 
-public final class com/topsort/analytics/EventPipelineKt {
-	public static final field UPLOAD_SIGNAL Ljava/lang/String;
-	public static final fun getEventDatastore (Landroid/content/Context;)Landroidx/datastore/core/DataStore;
-}
-
 public abstract interface class com/topsort/analytics/TopsortAnalytics {
 	public abstract fun reportClickOrganic (Lcom/topsort/analytics/model/Entity;Lcom/topsort/analytics/model/Placement;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public static synthetic fun reportClickOrganic$default (Lcom/topsort/analytics/TopsortAnalytics;Lcom/topsort/analytics/model/Entity;Lcom/topsort/analytics/model/Placement;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
@@ -157,72 +152,6 @@ public final class com/topsort/analytics/banners/BannerView : android/widget/Ima
 public final class com/topsort/analytics/banners/RunKt {
 	public static final fun buildBannerAuction (Lcom/topsort/analytics/banners/BannerConfig;)Lcom/topsort/analytics/model/auctions/Auction;
 	public static final fun runBannerAuction (Lcom/topsort/analytics/banners/BannerConfig;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public abstract class com/topsort/analytics/core/Connection : java/io/Closeable {
-	public fun <init> (Ljava/net/HttpURLConnection;Ljava/io/OutputStream;)V
-	public synthetic fun <init> (Ljava/net/HttpURLConnection;Ljava/io/OutputStream;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun close ()V
-	public final fun getOutputStream ()Ljava/io/OutputStream;
-}
-
-public final class com/topsort/analytics/core/EventTimestampKt {
-	public static final fun eventNow ()Ljava/lang/String;
-}
-
-public final class com/topsort/analytics/core/HttpClient {
-	public fun <init> (Ljava/lang/String;Lcom/topsort/analytics/core/RequestFactory;)V
-	public synthetic fun <init> (Ljava/lang/String;Lcom/topsort/analytics/core/RequestFactory;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun post (Ljava/lang/String;Ljava/lang/String;)Lcom/topsort/analytics/core/HttpResponse;
-}
-
-public final class com/topsort/analytics/core/HttpClientKt {
-	public static final field LIBRARY_VERSION D
-}
-
-public final class com/topsort/analytics/core/HttpResponse {
-	public fun <init> (ILjava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()I
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (ILjava/lang/String;Ljava/lang/String;)Lcom/topsort/analytics/core/HttpResponse;
-	public static synthetic fun copy$default (Lcom/topsort/analytics/core/HttpResponse;ILjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/topsort/analytics/core/HttpResponse;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBody ()Ljava/lang/String;
-	public final fun getCode ()I
-	public final fun getMessage ()Ljava/lang/String;
-	public fun hashCode ()I
-	public final fun isSuccessful ()Z
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/topsort/analytics/core/JsonExtensionsKt {
-	public static final fun getIntOrNull (Lorg/json/JSONObject;Ljava/lang/String;)Ljava/lang/Integer;
-	public static final fun getListFromJsonArray (Lorg/json/JSONArray;Lkotlin/jvm/functions/Function1;)Ljava/util/List;
-	public static final fun getStringListOrNull (Lorg/json/JSONObject;Ljava/lang/String;)Ljava/util/List;
-	public static final fun getStringOrNull (Lorg/json/JSONObject;Ljava/lang/String;)Ljava/lang/String;
-}
-
-public final class com/topsort/analytics/core/Logger {
-	public static final field INSTANCE Lcom/topsort/analytics/core/Logger;
-	public final fun getLog ()Ljava/util/List;
-}
-
-public final class com/topsort/analytics/core/RandomGeneratorKt {
-	public static final fun randomId (Ljava/lang/String;I)Ljava/lang/String;
-	public static synthetic fun randomId$default (Ljava/lang/String;IILjava/lang/Object;)Ljava/lang/String;
-}
-
-public final class com/topsort/analytics/core/RequestFactory {
-	public static final field CONNECTION_TIMEOUT I
-	public static final field Companion Lcom/topsort/analytics/core/RequestFactory$Companion;
-	public static final field READ_TIMEOUT I
-	public fun <init> ()V
-	public final fun upload (Ljava/lang/String;Ljava/lang/String;)Ljava/net/HttpURLConnection;
-}
-
-public final class com/topsort/analytics/core/RequestFactory$Companion {
 }
 
 public final class com/topsort/analytics/core/ServiceSettings {

--- a/TopsortAnalytics/build.gradle
+++ b/TopsortAnalytics/build.gradle
@@ -33,11 +33,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = '17'
+        jvmTarget = '11'
     }
 }
 

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/EventPipeline.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/EventPipeline.kt
@@ -41,9 +41,9 @@ private val KEY_CLICK_EVENTS = stringPreferencesKey("KEY_CLICK_EVENTS")
 private val KEY_PURCHASE_EVENTS = stringPreferencesKey("KEY_PURCHASE_EVENTS")
 
 @VisibleForTesting
-const val UPLOAD_SIGNAL = "UPLOAD"
+internal const val UPLOAD_SIGNAL = "UPLOAD"
 
-val Context.eventDatastore: DataStore<Preferences> by preferencesDataStore(name = PREFERENCES_NAME)
+internal val Context.eventDatastore: DataStore<Preferences> by preferencesDataStore(name = PREFERENCES_NAME)
 
 internal object EventPipeline {
 

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/core/EventTimestamp.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/core/EventTimestamp.kt
@@ -3,6 +3,6 @@ package com.topsort.analytics.core
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 
-fun eventNow(): String {
+internal fun eventNow(): String {
     return ISODateTimeFormat.dateTime().print(DateTime())
 }

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/core/HttpClient.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/core/HttpClient.kt
@@ -10,9 +10,9 @@ import java.net.MalformedURLException
 import java.net.URL
 import java.util.zip.GZIPOutputStream
 
-const val LIBRARY_VERSION = 1.0
+internal const val LIBRARY_VERSION = 1.0
 
-data class HttpResponse(
+internal data class HttpResponse(
     val code : Int,
     val message : String,
     val body: String? = null,
@@ -23,7 +23,7 @@ data class HttpResponse(
     }
 }
 
-class HttpClient (
+internal class HttpClient (
     private val apiHost: String,
     private val requestFactory: RequestFactory = RequestFactory()
 ) {
@@ -61,7 +61,7 @@ class HttpClient (
 /**
  * Wraps an HTTP connection. Callers can either read from the connection via the [ ] or write to the connection via [OutputStream].
  */
-abstract class Connection(
+internal abstract class Connection(
     private val connection: HttpURLConnection,
     val outputStream: OutputStream? = null,
 ) : Closeable {
@@ -90,7 +90,7 @@ internal fun HttpURLConnection.createPostConnection(): Connection {
 }
 
 
-class RequestFactory {
+internal class RequestFactory {
     fun upload(apiHost: String, bearerToken : String?): HttpURLConnection {
         val connection: HttpURLConnection = openConnection(apiHost)
         connection.requestMethod = "POST"

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/core/JsonExtensions.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/core/JsonExtensions.kt
@@ -3,26 +3,26 @@ package com.topsort.analytics.core
 import org.json.JSONArray
 import org.json.JSONObject
 
-fun JSONObject.getStringOrNull(name: String): String? {
+internal fun JSONObject.getStringOrNull(name: String): String? {
     return if (has(name)) {
         getString(name)
     } else null
 }
 
-fun JSONObject.getIntOrNull(name: String): Int? {
+internal fun JSONObject.getIntOrNull(name: String): Int? {
     return if (has(name)) {
         getInt(name)
     } else null
 }
 
-fun JSONObject.getStringListOrNull(name: String): List<String>? {
+internal fun JSONObject.getStringListOrNull(name: String): List<String>? {
     return if (has(name)) {
         val array = getJSONArray(name)
         return (0 until array.length()).map { array[it].toString() }
     } else null
 }
 
-fun <T> getListFromJsonArray(array: JSONArray, jsonDeserializer: (JSONObject) -> T): List<T> {
+internal fun <T> getListFromJsonArray(array: JSONArray, jsonDeserializer: (JSONObject) -> T): List<T> {
     return (0 until array.length()).map {
         jsonDeserializer(array.getJSONObject(it))
     }

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/core/Logger.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/core/Logger.kt
@@ -1,5 +1,5 @@
 package com.topsort.analytics.core
 
-object Logger {
+internal object Logger {
     val log = mutableListOf<String>()
 }

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/core/RandomGenerator.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/core/RandomGenerator.kt
@@ -1,6 +1,6 @@
 package com.topsort.analytics.core
 
-fun randomId(prefix : String = "", size : Int = 32): String {
+internal fun randomId(prefix : String = "", size : Int = 32): String {
     val allowedCharacters =   ('a'..'z') + ('A'..'Z') + ('0'..'9')
     val rand = List(size) { allowedCharacters.random() }.joinToString("")
     return "${prefix}${rand}"

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/model/PurchaseEvent.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/model/PurchaseEvent.kt
@@ -92,6 +92,11 @@ data class PurchasedItem(
     val productId: String,
 
     @IntRange(from = 1) val quantity: Int,
+
+    /**
+     * Unit price in the smallest currency unit (e.g., cents for USD).
+     * Example: 1295 = $12.95
+     */
     @IntRange(from = 1) val unitPrice: Int? = null,
 
     /**

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/worker/EventEmitterWorker.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/worker/EventEmitterWorker.kt
@@ -1,6 +1,7 @@
 package com.topsort.analytics.worker
 
 import android.content.Context
+import android.util.Log
 import androidx.work.Worker
 import androidx.work.WorkerParameters
 import com.topsort.analytics.Cache
@@ -71,8 +72,12 @@ internal class EventEmitterWorker(
     private fun reportImpression(impressionEvent: ImpressionEvent): Boolean {
         return try {
             val response = TopsortAnalyticsHttpService.service.reportImpression(impressionEvent)
+            if (!response.isSuccessful()) {
+                Log.e(TAG, "Failed to report impression: ${response.code} ${response.message}")
+            }
             response.isSuccessful()
-        } catch (ignored: Exception) {
+        } catch (e: Exception) {
+            Log.e(TAG, "Exception reporting impression", e)
             false
         }
     }
@@ -80,8 +85,12 @@ internal class EventEmitterWorker(
     private fun reportClick(clickEvent: ClickEvent): Boolean {
         return try {
             val response = TopsortAnalyticsHttpService.service.reportClick(clickEvent)
+            if (!response.isSuccessful()) {
+                Log.e(TAG, "Failed to report click: ${response.code} ${response.message}")
+            }
             response.isSuccessful()
-        } catch (ignored: Exception) {
+        } catch (e: Exception) {
+            Log.e(TAG, "Exception reporting click", e)
             false
         }
     }
@@ -89,13 +98,19 @@ internal class EventEmitterWorker(
     private fun reportPurchase(purchaseEvent: PurchaseEvent): Boolean {
         return try {
             val response = TopsortAnalyticsHttpService.service.reportPurchase(purchaseEvent)
+            if (!response.isSuccessful()) {
+                Log.e(TAG, "Failed to report purchase: ${response.code} ${response.message}")
+            }
             response.isSuccessful()
-        } catch (ignored: Exception) {
+        } catch (e: Exception) {
+            Log.e(TAG, "Exception reporting purchase", e)
             false
         }
     }
 
     companion object {
+        private const val TAG = "TopsortEventEmitter"
+
         const val EXTRA_RECORD_ID = "EXTRA_RECORD_ID"
         const val EXTRA_EVENT_TYPE = "EXTRA_EVENT_TYPE"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,11 +36,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = '17'
+        jvmTarget = '11'
     }
     buildFeatures {
         buildConfig = true

--- a/build.gradle
+++ b/build.gradle
@@ -15,11 +15,11 @@ plugins {
 
 subprojects {
     tasks.withType(Detekt).configureEach {
-        jvmTarget = '17'
+        jvmTarget = '11'
         autoCorrect = true
         buildUponDefaultConfig = true
     }
     tasks.withType(DetektCreateBaselineTask).configureEach {
-        jvmTarget = '17'
+        jvmTarget = '11'
     }
 }


### PR DESCRIPTION
## Summary
- Mark `core/` package utilities as `internal`: HttpClient, HttpResponse, Connection, RequestFactory, LIBRARY_VERSION, JsonExtensions, RandomGenerator, EventTimestamp, Logger
- Mark `EventPipeline.kt` top-level declarations as `internal`: UPLOAD_SIGNAL, eventDatastore
- Regenerate BCV API dump to reflect the reduced public surface

## Context
The entire `core/` package contains implementation details (HTTP client, JSON helpers, timestamp utils, etc.) that were unintentionally public. No consumer should depend on these — they should only use the `Analytics` singleton, model classes, and `BannerConfig`/auction types. Making them `internal` prevents future accidental breaking changes from internal refactoring.

## Breaking change
This removes the following from the public API surface:
- `com.topsort.analytics.core.*` (HttpClient, HttpResponse, Connection, RequestFactory, JsonExtensions, RandomGenerator, EventTimestamp, Logger, LIBRARY_VERSION)
- `com.topsort.analytics.EventPipelineKt` (UPLOAD_SIGNAL, eventDatastore)

Any consumer using these directly will get a compilation error. This is unlikely since these are implementation details, but should be released as a minor/major version bump.

## Stack
- Based on: #90

## Test plan
- [x] Unit tests pass (`./gradlew :TopsortAnalytics:test`)
- [x] Detekt passes
- [x] apiDump + apiCheck pass
- [ ] Verify BCV diff only removes internal utilities, not public API

🤖 Generated with [Claude Code](https://claude.com/claude-code)