### PR TITLE
fix: use EncryptedSharedPreferences for token storage

### DIFF
--- a/TopsortAnalytics/build.gradle
+++ b/TopsortAnalytics/build.gradle
@@ -89,6 +89,7 @@ dependencies {
     implementation libs.androidx.core.ktx
     implementation libs.androidx.annotation
     implementation libs.androidx.work.runtime
+    implementation libs.androidx.security.crypto
     implementation libs.jodatime
     implementation libs.coil
 

--- a/TopsortAnalytics/consumer-rules.pro
+++ b/TopsortAnalytics/consumer-rules.pro
@@ -44,12 +44,8 @@
 -keep class com.topsort.analytics.service.AuctionsHttpService { *; }
 -keep class com.topsort.analytics.service.TopsortAuctionsHttpService { *; }
 
-# Keep HttpResponse and HttpClient (public API)
--keep class com.topsort.analytics.core.HttpResponse { *; }
--keep class com.topsort.analytics.core.HttpClient { *; }
--keep class com.topsort.analytics.core.RequestFactory { *; }
--keep class com.topsort.analytics.core.RequestFactory$Companion { *; }
-
 # Keep WorkManager worker class names (WorkManager uses reflection)
 -keep class com.topsort.analytics.worker.EventEmitterWorker { *; }
--keep class com.topsort.analytics.EventPipeline$EventEmitterWorker { *; }
+
+# Keep AndroidX Security Crypto (used by EncryptedSharedPreferences)
+-keep class androidx.security.crypto.** { *; }

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/Cache.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/Cache.kt
@@ -76,6 +76,11 @@ internal object Cache {
     @Suppress("TooGenericExceptionCaught")
     private fun migrateFromPlaintextPreferences(context: Context) {
         val plaintext = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+
+        // Skip migration if encryption failed and we fell back to the same plaintext prefs.
+        // Clearing would wipe all data since both references point to the same instance.
+        if (plaintext === preferences) return
+
         val plaintextToken = plaintext.getString(KEY_TOKEN, "")
         if (plaintextToken.isNullOrEmpty()) return
 

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/Cache.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/Cache.kt
@@ -3,17 +3,23 @@ package com.topsort.analytics
 import android.content.Context
 import android.content.SharedPreferences
 import android.text.TextUtils
+import android.util.Log
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
 import com.topsort.analytics.model.ClickEvent
 import com.topsort.analytics.model.ImpressionEvent
 import com.topsort.analytics.model.PurchaseEvent
 import java.util.Locale
 
 private const val PREFERENCES_NAME = "TOPSORT_EVENTS_CACHE"
+private const val ENCRYPTED_PREFERENCES_NAME = "TOPSORT_EVENTS_CACHE_ENCRYPTED"
 
 private const val KEY_TOKEN = "KEY_TOKEN"
 private const val KEY_SESSION_ID = "KEY_SESSION_ID"
 private const val KEY_RECORD = "KEY_RECORD_%d"
 private const val KEY_RECENT_RECORD_ID = "KEY_RECORD_ID"
+
+private const val TAG = "TopsortCache"
 
 internal object Cache {
 
@@ -42,10 +48,53 @@ internal object Cache {
 
     fun initialize(context: Context) {
         applicationContext = context.applicationContext
-        preferences = applicationContext.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+        preferences = createEncryptedPreferences(applicationContext)
+
+        migrateFromPlaintextPreferences(applicationContext)
 
         token = preferences.getString(KEY_TOKEN, "")!!
         opaqueUserId = preferences.getString(KEY_SESSION_ID, "")!!
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun createEncryptedPreferences(context: Context): SharedPreferences {
+        return try {
+            val masterKeyAlias = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
+            EncryptedSharedPreferences.create(
+                ENCRYPTED_PREFERENCES_NAME,
+                masterKeyAlias,
+                context,
+                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+            )
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to create encrypted preferences, falling back to plaintext", e)
+            context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun migrateFromPlaintextPreferences(context: Context) {
+        val plaintext = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+        val plaintextToken = plaintext.getString(KEY_TOKEN, "")
+        if (plaintextToken.isNullOrEmpty()) return
+
+        try {
+            val editor = preferences.edit()
+            for ((key, value) in plaintext.all) {
+                when (value) {
+                    is String -> editor.putString(key, value)
+                    is Long -> editor.putLong(key, value)
+                    is Int -> editor.putInt(key, value)
+                    is Boolean -> editor.putBoolean(key, value)
+                    is Float -> editor.putFloat(key, value)
+                }
+            }
+            editor.apply()
+            plaintext.edit().clear().apply()
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to migrate plaintext preferences", e)
+        }
     }
 
     fun setup(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ core-ktx               = "1.13.1"
 annotation             = "1.7.1"
 work                   = "2.9.0"
 datastore              = "1.1.1"
+security-crypto        = "1.1.0-alpha06"
 lifecycle              = "2.8.4"
 material               = "1.13.0"
 jodatime               = "2.14.0"
@@ -27,6 +28,7 @@ androidx-core-ktx              = { module = "androidx.core:core-ktx",           
 androidx-annotation            = { module = "androidx.annotation:annotation",                   version.ref = "annotation" }
 androidx-work-runtime          = { module = "androidx.work:work-runtime-ktx",                   version.ref = "work" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences",         version.ref = "datastore" }
+androidx-security-crypto       = { module = "androidx.security:security-crypto",                version.ref = "security-crypto" }
 androidx-lifecycle-runtime     = { module = "androidx.lifecycle:lifecycle-runtime-ktx",         version.ref = "lifecycle" }
 material                       = { module = "com.google.android.material:material",              version.ref = "material" }
 jodatime                       = { module = "joda-time:joda-time",                              version.ref = "jodatime" }


### PR DESCRIPTION
## Summary
- Replace plaintext `SharedPreferences` with `EncryptedSharedPreferences` (AES256-GCM) for bearer token and session ID storage at rest
- Add automatic migration from plaintext to encrypted preferences on first run after upgrade
- Fall back gracefully to plaintext `SharedPreferences` if KeyStore/encryption fails
- Clean up stale `consumer-rules.pro` entries for now-internal core classes and removed EventPipeline

## Context
Bearer tokens were stored in plaintext `SharedPreferences`, readable by any process with root access or backup extraction. `EncryptedSharedPreferences` encrypts both keys (AES256-SIV) and values (AES256-GCM) using the Android KeyStore, making tokens unreadable without the device's hardware-backed key.

## Migration strategy
On `initialize()`:
1. Create encrypted preferences (new file name `TOPSORT_EVENTS_CACHE_ENCRYPTED`)
2. Check if old plaintext preferences (`TOPSORT_EVENTS_CACHE`) contain data
3. If so, copy all entries to encrypted preferences, then clear plaintext
4. If encryption setup fails (e.g., broken KeyStore on some devices), fall back to plaintext with a `Log.e`

## New dependency
- `androidx.security:security-crypto:1.1.0-alpha06` (~45 KB, transitively pulls Tink)

## Stack
- Based on: #92

## Test plan
- [x] Unit tests pass (`./gradlew :TopsortAnalytics:test`)
- [x] Detekt passes
- [x] apiCheck passes (Cache is `internal`, no public API change)
- [ ] Manual test: verify token persists across app restarts with encrypted prefs
- [ ] Manual test: verify migration works (install old version, upgrade, verify token still works)
- [ ] Manual test: verify fallback works on emulator with broken KeyStore

🤖 Generated with [Claude Code](https://claude.com/claude-code)