### PR TITLE
refactor: replace Auction.Factory methods with sealed AuctionConfig class

### DIFF
--- a/TopsortAnalytics/api/TopsortAnalytics.api
+++ b/TopsortAnalytics/api/TopsortAnalytics.api
@@ -459,6 +459,7 @@ public final class com/topsort/analytics/model/auctions/ApiConstants {
 }
 
 public final class com/topsort/analytics/model/auctions/Auction {
+	public static final field Companion Lcom/topsort/analytics/model/auctions/Auction$Companion;
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()I
 	public final fun component3 ()Lcom/topsort/analytics/model/auctions/Auction$Products;
@@ -499,6 +500,10 @@ public final class com/topsort/analytics/model/auctions/Auction$Category {
 	public fun hashCode ()I
 	public final fun toJsonObject ()Lorg/json/JSONObject;
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/topsort/analytics/model/auctions/Auction$Companion {
+	public final fun fromConfig (Lcom/topsort/analytics/model/auctions/AuctionConfig;)Lcom/topsort/analytics/model/auctions/Auction;
 }
 
 public final class com/topsort/analytics/model/auctions/Auction$Factory {
@@ -558,6 +563,93 @@ public final class com/topsort/analytics/model/auctions/Auction$Products {
 	public static synthetic fun copy$default (Lcom/topsort/analytics/model/auctions/Auction$Products;Ljava/util/List;ILjava/lang/Object;)Lcom/topsort/analytics/model/auctions/Auction$Products;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getIds ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/topsort/analytics/model/auctions/AuctionConfig {
+	public synthetic fun <init> (ILjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ILjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getGeoTargeting ()Ljava/lang/String;
+	public final fun getSlots ()I
+}
+
+public final class com/topsort/analytics/model/auctions/AuctionConfig$CategoryDisjunctions : com/topsort/analytics/model/auctions/AuctionConfig {
+	public fun <init> (ILjava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (ILjava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (ILjava/util/List;Ljava/lang/String;)Lcom/topsort/analytics/model/auctions/AuctionConfig$CategoryDisjunctions;
+	public static synthetic fun copy$default (Lcom/topsort/analytics/model/auctions/AuctionConfig$CategoryDisjunctions;ILjava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lcom/topsort/analytics/model/auctions/AuctionConfig$CategoryDisjunctions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDisjunctions ()Ljava/util/List;
+	public final fun getGeo ()Ljava/lang/String;
+	public final fun getNumSlots ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/topsort/analytics/model/auctions/AuctionConfig$CategoryMultiple : com/topsort/analytics/model/auctions/AuctionConfig {
+	public fun <init> (ILjava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (ILjava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (ILjava/util/List;Ljava/lang/String;)Lcom/topsort/analytics/model/auctions/AuctionConfig$CategoryMultiple;
+	public static synthetic fun copy$default (Lcom/topsort/analytics/model/auctions/AuctionConfig$CategoryMultiple;ILjava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lcom/topsort/analytics/model/auctions/AuctionConfig$CategoryMultiple;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCategories ()Ljava/util/List;
+	public final fun getGeo ()Ljava/lang/String;
+	public final fun getNumSlots ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/topsort/analytics/model/auctions/AuctionConfig$CategorySingle : com/topsort/analytics/model/auctions/AuctionConfig {
+	public fun <init> (ILjava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (ILjava/lang/String;Ljava/lang/String;)Lcom/topsort/analytics/model/auctions/AuctionConfig$CategorySingle;
+	public static synthetic fun copy$default (Lcom/topsort/analytics/model/auctions/AuctionConfig$CategorySingle;ILjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/topsort/analytics/model/auctions/AuctionConfig$CategorySingle;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCategory ()Ljava/lang/String;
+	public final fun getGeo ()Ljava/lang/String;
+	public final fun getNumSlots ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/topsort/analytics/model/auctions/AuctionConfig$Keyword : com/topsort/analytics/model/auctions/AuctionConfig {
+	public fun <init> (ILjava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (ILjava/lang/String;Ljava/lang/String;)Lcom/topsort/analytics/model/auctions/AuctionConfig$Keyword;
+	public static synthetic fun copy$default (Lcom/topsort/analytics/model/auctions/AuctionConfig$Keyword;ILjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/topsort/analytics/model/auctions/AuctionConfig$Keyword;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGeo ()Ljava/lang/String;
+	public final fun getKeyword ()Ljava/lang/String;
+	public final fun getNumSlots ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/topsort/analytics/model/auctions/AuctionConfig$ProductIds : com/topsort/analytics/model/auctions/AuctionConfig {
+	public fun <init> (ILjava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (ILjava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (ILjava/util/List;Ljava/lang/String;)Lcom/topsort/analytics/model/auctions/AuctionConfig$ProductIds;
+	public static synthetic fun copy$default (Lcom/topsort/analytics/model/auctions/AuctionConfig$ProductIds;ILjava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lcom/topsort/analytics/model/auctions/AuctionConfig$ProductIds;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGeo ()Ljava/lang/String;
+	public final fun getIds ()Ljava/util/List;
+	public final fun getNumSlots ()I
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/model/auctions/Auction.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/model/auctions/Auction.kt
@@ -46,8 +46,58 @@ data class Auction private constructor(
         }
     }
 
+    companion object {
+        /**
+         * Builds an [Auction] from an [AuctionConfig] sealed class instance.
+         *
+         * This is the preferred way to create sponsored listing auctions:
+         * ```
+         * val config = AuctionConfig.ProductIds(numSlots = 1, ids = listOf("p1", "p2"))
+         * val auction = Auction.fromConfig(config)
+         * ```
+         */
+        fun fromConfig(config: AuctionConfig): Auction {
+            return when (config) {
+                is AuctionConfig.ProductIds -> Auction(
+                    type = "listings",
+                    slots = config.slots,
+                    products = Products(config.ids),
+                    geoTargeting = config.geoTargeting?.let { GeoTargeting(it) },
+                )
+                is AuctionConfig.CategorySingle -> Auction(
+                    type = "listings",
+                    slots = config.slots,
+                    category = Category(id = config.category),
+                    geoTargeting = config.geoTargeting?.let { GeoTargeting(it) },
+                )
+                is AuctionConfig.CategoryMultiple -> Auction(
+                    type = "listings",
+                    slots = config.slots,
+                    category = Category(ids = config.categories),
+                    geoTargeting = config.geoTargeting?.let { GeoTargeting(it) },
+                )
+                is AuctionConfig.CategoryDisjunctions -> Auction(
+                    type = "listings",
+                    slots = config.slots,
+                    category = Category(disjunctions = config.disjunctions),
+                    geoTargeting = config.geoTargeting?.let { GeoTargeting(it) },
+                )
+                is AuctionConfig.Keyword -> Auction(
+                    type = "listings",
+                    slots = config.slots,
+                    searchQuery = config.keyword,
+                    geoTargeting = config.geoTargeting?.let { GeoTargeting(it) },
+                )
+            }
+        }
+    }
+
     object Factory {
 
+        @Deprecated(
+            "Use AuctionConfig.ProductIds with Auction.fromConfig() instead",
+            ReplaceWith("Auction.fromConfig(AuctionConfig.ProductIds(slots, ids, geoTargeting))")
+        )
         @JvmOverloads
         fun buildSponsoredListingAuctionProductIds(
             slots: Int,
@@ -65,6 +115,10 @@ data class Auction private constructor(
             )
         }
 
+        @Deprecated(
+            "Use AuctionConfig.CategorySingle with Auction.fromConfig() instead",
+            ReplaceWith("Auction.fromConfig(AuctionConfig.CategorySingle(slots, category, geoTargeting))")
+        )
         @JvmOverloads
         fun buildSponsoredListingAuctionCategorySingle(
             slots: Int,
@@ -82,6 +136,10 @@ data class Auction private constructor(
             )
         }
 
+        @Deprecated(
+            "Use AuctionConfig.CategoryMultiple with Auction.fromConfig() instead",
+            ReplaceWith("Auction.fromConfig(AuctionConfig.CategoryMultiple(slots, categories, geoTargeting))")
+        )
         @JvmOverloads
         fun buildSponsoredListingAuctionCategoryMultiple(
             slots: Int,
@@ -99,6 +157,10 @@ data class Auction private constructor(
             )
         }
 
+        @Deprecated(
+            "Use AuctionConfig.CategoryDisjunctions with Auction.fromConfig() instead",
+            ReplaceWith("Auction.fromConfig(AuctionConfig.CategoryDisjunctions(slots, disjunctions, geoTargeting))")
+        )
         @JvmOverloads
         fun buildSponsoredListingAuctionCategoryDisjunctions(
             slots: Int,
@@ -116,6 +178,10 @@ data class Auction private constructor(
             )
         }
 
+        @Deprecated(
+            "Use AuctionConfig.Keyword with Auction.fromConfig() instead",
+            ReplaceWith("Auction.fromConfig(AuctionConfig.Keyword(slots, keyword, geoTargeting))")
+        )
         @JvmOverloads
         fun buildSponsoredListingAuctionKeyword(
             slots: Int,

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/model/auctions/AuctionConfig.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/model/auctions/AuctionConfig.kt
@@ -1,0 +1,94 @@
+package com.topsort.analytics.model.auctions
+
+/**
+ * Sealed class representing the configuration for a sponsored listing auction.
+ *
+ * Use one of the subclasses to specify the auction type, then pass it to
+ * [Auction.fromConfig] to build the low-level [Auction] object.
+ *
+ * @property slots number of ad slots to fill (must be positive)
+ * @property geoTargeting optional location string for geo-targeted auctions
+ */
+sealed class AuctionConfig(
+    val slots: Int,
+    val geoTargeting: String? = null,
+) {
+    init {
+        require(slots > 0) { "Number of slots must be positive" }
+    }
+
+    /**
+     * Auction targeting specific product IDs.
+     *
+     * @property ids list of product IDs to target (must not be empty)
+     */
+    data class ProductIds(
+        val numSlots: Int,
+        val ids: List<String>,
+        val geo: String? = null,
+    ) : AuctionConfig(numSlots, geo) {
+        init {
+            require(ids.isNotEmpty()) { "Product IDs list cannot be empty" }
+        }
+    }
+
+    /**
+     * Auction targeting a single category.
+     *
+     * @property category the category to target (must not be blank)
+     */
+    data class CategorySingle(
+        val numSlots: Int,
+        val category: String,
+        val geo: String? = null,
+    ) : AuctionConfig(numSlots, geo) {
+        init {
+            require(category.isNotBlank()) { "Category cannot be blank" }
+        }
+    }
+
+    /**
+     * Auction targeting multiple categories.
+     *
+     * @property categories list of categories to target (must not be empty)
+     */
+    data class CategoryMultiple(
+        val numSlots: Int,
+        val categories: List<String>,
+        val geo: String? = null,
+    ) : AuctionConfig(numSlots, geo) {
+        init {
+            require(categories.isNotEmpty()) { "Categories list cannot be empty" }
+        }
+    }
+
+    /**
+     * Auction targeting category disjunctions.
+     *
+     * @property disjunctions list of category disjunctions (must not be empty)
+     */
+    data class CategoryDisjunctions(
+        val numSlots: Int,
+        val disjunctions: List<List<String>>,
+        val geo: String? = null,
+    ) : AuctionConfig(numSlots, geo) {
+        init {
+            require(disjunctions.isNotEmpty()) { "Disjunctions list cannot be empty" }
+        }
+    }
+
+    /**
+     * Auction targeting a search keyword.
+     *
+     * @property keyword the keyword to target (must not be blank)
+     */
+    data class Keyword(
+        val numSlots: Int,
+        val keyword: String,
+        val geo: String? = null,
+    ) : AuctionConfig(numSlots, geo) {
+        init {
+            require(keyword.isNotBlank()) { "Keyword cannot be blank" }
+        }
+    }
+}

--- a/TopsortAnalytics/src/test/java/com/topsort/analytics/service/TopsortAuctionsHttpServiceTest.kt
+++ b/TopsortAnalytics/src/test/java/com/topsort/analytics/service/TopsortAuctionsHttpServiceTest.kt
@@ -1,6 +1,7 @@
 package com.topsort.analytics.service
 
 import com.topsort.analytics.model.auctions.Auction
+import com.topsort.analytics.model.auctions.AuctionConfig
 import com.topsort.analytics.model.auctions.AuctionError
 import com.topsort.analytics.model.auctions.AuctionRequest
 import com.topsort.analytics.model.auctions.AuctionResponse
@@ -21,7 +22,7 @@ class TopsortAuctionsHttpServiceTest {
     private val mockService = mockk<AuctionsHttpService>()
 
     private val minimalRequest = AuctionRequest(
-        listOf(Auction.Factory.buildSponsoredListingAuctionProductIds(1, listOf("p1")))
+        listOf(Auction.fromConfig(AuctionConfig.ProductIds(numSlots = 1, ids = listOf("p1"))))
     )
 
     @Before


### PR DESCRIPTION
## Summary
- Add `AuctionConfig` sealed class with 5 subclasses for type-safe sponsored listing auction configuration
- Add `Auction.fromConfig(AuctionConfig)` bridge function on `Auction.Companion`
- Deprecate the 5 `Auction.Factory.buildSponsoredListing*` methods with `@Deprecated(replaceWith = ...)`
- Update test to use the new sealed class API
- Regenerate BCV API dump

## Context
The `Auction.Factory` has 10 methods — 5 for sponsored listings and 5 for banners. The banner methods are already wrapped by `BannerConfig` (used via `buildBannerAuction()` in `run.kt`). This PR applies the same sealed-class pattern to the sponsored listing methods:

| Old (Factory) | New (AuctionConfig) |
|---|---|
| `buildSponsoredListingAuctionProductIds(slots, ids, geo)` | `AuctionConfig.ProductIds(numSlots, ids, geo)` |
| `buildSponsoredListingAuctionCategorySingle(slots, cat, geo)` | `AuctionConfig.CategorySingle(numSlots, category, geo)` |
| `buildSponsoredListingAuctionCategoryMultiple(slots, cats, geo)` | `AuctionConfig.CategoryMultiple(numSlots, categories, geo)` |
| `buildSponsoredListingAuctionCategoryDisjunctions(slots, disj, geo)` | `AuctionConfig.CategoryDisjunctions(numSlots, disjunctions, geo)` |
| `buildSponsoredListingAuctionKeyword(slots, kw, geo)` | `AuctionConfig.Keyword(numSlots, keyword, geo)` |

Benefits:
- Exhaustive `when` matching at compile time
- Validation in `init {}` blocks (no need to call factory methods for validation)
- Consistent with `BannerConfig` pattern
- Better IDE discoverability

## Migration
The old factory methods are deprecated but still functional. Consumers get IDE warnings with automatic replacement suggestions.

## Stack
- Based on: #93

## Test plan
- [x] Unit tests pass (`./gradlew :TopsortAnalytics:test`)
- [x] Detekt passes
- [x] apiDump + apiCheck pass
- [ ] Verify `@Deprecated(replaceWith = ...)` provides correct IDE quick-fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)