### PR TITLE
fix: remove placeholder bid ID from PurchasedItem example

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,6 @@ fun reportPurchase() {
         productId = "productId",
         quantity = 20,
         unitPrice = 1295, // price in cents ($12.95)
-        resolvedBidId = "<The bid id from the auction winner>"
     )
 
     Analytics.reportPurchase(


### PR DESCRIPTION
Removed placeholder for resolvedBidId in PurchasedItem.

## Summary

Resolved Bid id is not supposed to be in purchased item, removing for consistency.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change (public API modified)
- [ ] Refactoring / internal improvement
- [x] Documentation
- [ ] CI / build tooling

## Checklist

- [ ] Tests added or updated for changed behaviour
- [ ] `./gradlew detekt` passes locally
- [ ] `./gradlew :TopsortAnalytics:test` passes locally
- [ ] If public API was changed: ran `./gradlew :TopsortAnalytics:apiDump` and committed the updated `TopsortAnalytics/api/TopsortAnalytics.api`
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, `docs:`, etc.)
- [ ] CHANGELOG updated if this is a user-visible change (release-please handles this automatically from commit messages)

## Testing

<!-- Describe how you tested this change. -->
