### PR TITLE
chore(deps): bump AGP from 8.5.1 to 8.13.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp                    = "8.5.1"
+agp                    = "8.13.0"
 kotlin                 = "2.3.10"
 detekt                 = "1.23.8"
 vanniktech-publish     = "0.29.0"


### PR DESCRIPTION
## Summary
- Bumps Android Gradle Plugin from 8.5.1 to 8.13.0
- Unblocks #96 (androidx group updates, requires AGP ≥8.9.1) and #70 (maven-publish 0.36.0, requires AGP ≥8.13.0)
- AGP 9.x was considered (#97) but closed due to BCV incompatibility ([Kotlin/binary-compatibility-validator#312](https://github.com/Kotlin/binary-compatibility-validator/issues/312))

## Test plan
- [x] `detekt` passes locally
- [x] Unit tests pass locally
- [x] `apiCheck` passes locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)