### PR TITLE
fix: prevent crash on explicit JSON null values

### DIFF
--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/core/JsonExtensions.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/core/JsonExtensions.kt
@@ -4,21 +4,21 @@ import org.json.JSONArray
 import org.json.JSONObject
 
 internal fun JSONObject.getStringOrNull(name: String): String? {
-    return if (has(name)) {
+    return if (has(name) && !isNull(name)) {
         getString(name)
     } else null
 }
 
 internal fun JSONObject.getIntOrNull(name: String): Int? {
-    return if (has(name)) {
+    return if (has(name) && !isNull(name)) {
         getInt(name)
     } else null
 }
 
 internal fun JSONObject.getStringListOrNull(name: String): List<String>? {
-    return if (has(name)) {
+    return if (has(name) && !isNull(name)) {
         val array = getJSONArray(name)
-        return (0 until array.length()).map { array[it].toString() }
+        (0 until array.length()).map { array[it].toString() }
     } else null
 }
 

--- a/TopsortAnalytics/src/test/java/com/topsort/analytics/core/JsonExtensionsTest.kt
+++ b/TopsortAnalytics/src/test/java/com/topsort/analytics/core/JsonExtensionsTest.kt
@@ -1,0 +1,78 @@
+package com.topsort.analytics.core
+
+import org.assertj.core.api.Assertions.assertThat
+import org.json.JSONObject
+import org.junit.Test
+
+internal class JsonExtensionsTest {
+
+    @Test
+    fun `getStringOrNull returns string when present`() {
+        val json = JSONObject("""{"name": "test"}""")
+
+        assertThat(json.getStringOrNull("name")).isEqualTo("test")
+    }
+
+    @Test
+    fun `getStringOrNull returns null when key missing`() {
+        val json = JSONObject("""{"other": "value"}""")
+
+        assertThat(json.getStringOrNull("name")).isNull()
+    }
+
+    @Test
+    fun `getStringOrNull returns null when value is explicit JSON null`() {
+        val json = JSONObject("""{"name": null}""")
+
+        assertThat(json.getStringOrNull("name")).isNull()
+    }
+
+    @Test
+    fun `getIntOrNull returns int when present`() {
+        val json = JSONObject("""{"count": 42}""")
+
+        assertThat(json.getIntOrNull("count")).isEqualTo(42)
+    }
+
+    @Test
+    fun `getIntOrNull returns null when key missing`() {
+        val json = JSONObject("""{"other": 1}""")
+
+        assertThat(json.getIntOrNull("count")).isNull()
+    }
+
+    @Test
+    fun `getIntOrNull returns null when value is explicit JSON null`() {
+        val json = JSONObject("""{"count": null}""")
+
+        assertThat(json.getIntOrNull("count")).isNull()
+    }
+
+    @Test
+    fun `getStringListOrNull returns list when present`() {
+        val json = JSONObject("""{"items": ["a", "b", "c"]}""")
+
+        assertThat(json.getStringListOrNull("items")).containsExactly("a", "b", "c")
+    }
+
+    @Test
+    fun `getStringListOrNull returns null when key missing`() {
+        val json = JSONObject("""{"other": []}""")
+
+        assertThat(json.getStringListOrNull("items")).isNull()
+    }
+
+    @Test
+    fun `getStringListOrNull returns null when value is explicit JSON null`() {
+        val json = JSONObject("""{"items": null}""")
+
+        assertThat(json.getStringListOrNull("items")).isNull()
+    }
+
+    @Test
+    fun `getStringListOrNull returns empty list for empty array`() {
+        val json = JSONObject("""{"items": []}""")
+
+        assertThat(json.getStringListOrNull("items")).isEmpty()
+    }
+}


### PR DESCRIPTION
 ## Summary

  Fix JSON null handling that could cause crashes when the API returns explicit null values.

  ## Problem

The getStringOrNull(), getIntOrNull(), and getStringListOrNull() extensions only checked has(name) but not isNull(name). When the API returns {"field": null} (explicit null), calling getString() throws an exception because the key  exists but the value is null.

 ## Solution 

Added && !isNull(name) check to all three extension functions.

  ## Changes
  - JsonExtensions.kt: Fix 3 functions to handle explicit JSON nulls
  - JsonExtensionsTest.kt: Add 10 unit tests covering all edge cases

 ## Test plan

  - getStringOrNull returns null for missing keys
  - getStringOrNull returns null for explicit null values
  - getIntOrNull returns null for missing keys
  - getIntOrNull returns null for explicit null values
  - getStringListOrNull returns null for missing keys
  - getStringListOrNull returns null for explicit null values
  - All functions return correct values when data is present
  - CI passes

  🤖 Generated with https://claude.com/claude-code