### PR TITLE
feat: add Page model and PageView event tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,53 @@ fun reportPurchase() {
 }
 ```
 
+##### Page View events
+
+Track page views to understand user navigation patterns:
+
+```kotlin
+import com.topsort.analytics.model.Page
+
+// Simple home page view
+Analytics.reportPageView(
+    page = Page.Factory.build(type = Page.TYPE_HOME)
+)
+
+// Product detail page with ID
+Analytics.reportPageView(
+    page = Page.Factory.buildWithId(
+        type = Page.TYPE_PDP,
+        pageId = "product-123"
+    ),
+    deviceType = "mobile",
+    channel = "onsite"
+)
+
+// Search results page with query
+Analytics.reportPageView(
+    page = Page.Factory.buildWithId(
+        type = Page.TYPE_SEARCH,
+        pageId = "search-results",
+        value = "running shoes"
+    )
+)
+
+// Category page with hierarchy
+Analytics.reportPageView(
+    page = Page.Factory.buildWithValues(
+        type = Page.TYPE_CATEGORY,
+        values = listOf("Electronics", "Phones", "Smartphones"),
+        pageId = "cat-smartphones"
+    )
+)
+```
+
+**Available page types:** `Page.TYPE_HOME`, `Page.TYPE_CATEGORY`, `Page.TYPE_PDP`, `Page.TYPE_SEARCH`, `Page.TYPE_CART`, `Page.TYPE_OTHER`
+
+**Optional parameters:**
+- `deviceType`: `"desktop"` or `"mobile"`
+- `channel`: `"onsite"`, `"offsite"`, or `"instore"`
+
 ## Banner Auctions with Error Handling and Callbacks
 
 The library provides comprehensive support for banner auctions with robust error handling and callbacks:

--- a/README.md
+++ b/README.md
@@ -1,205 +1,103 @@
-# Topsort kotlin library
+# topsort.kt
 
-An Android library for interacting with the Topsort APIs. We provide support for sending events and running banner auctions with comprehensive error handling and callback support.
+[![Build](https://github.com/Topsort/topsort.kt/actions/workflows/tests.yaml/badge.svg)](https://github.com/Topsort/topsort.kt/actions/workflows/tests.yaml)
+[![Maven Central](https://img.shields.io/maven-central/v/com.topsort/topsort-kt.svg)](https://central.sonatype.com/artifact/com.topsort/topsort-kt)
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.0+-7F52FF.svg?logo=kotlin&logoColor=white)](https://kotlinlang.org)
+[![Android API](https://img.shields.io/badge/API-24+-34A853.svg?logo=android&logoColor=white)](https://developer.android.com/about/versions/nougat)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/Topsort/topsort.kt/blob/main/LICENSE)
 
-Licensed under [MIT][1].
+Android SDK for [Topsort's](https://www.topsort.com) retail media platform. Provides auction execution, event tracking (impressions, clicks, purchases, page views), and banner ad components.
+
+## Features
+
+- **Auctions** - Run sponsored listing and banner auctions
+- **Event Tracking** - Report impressions, clicks, purchases, and page views
+- **Banner Ads** - Ready-to-use `BannerView` component with automatic tracking
+- **Offline Support** - Events are cached and delivered when connectivity returns
+- **Zero Configuration** - Sensible defaults with optional customization
 
 ## Requirements
 
-- Minimum Java version: 11
-- Android SDK: 24+
-- `INTERNET` permission (add to your `AndroidManifest.xml` if not already present)
+- Android API 24+ (Android 7.0 Nougat)
+- Java 11+
 
-## Installation / Getting started
+## Installation
 
-We recommend installing the library via Gradle.
-Simply add the dependency to your build.gradle file:
+Add the dependency to your `build.gradle`:
 
 ```gradle
 dependencies {
-    ...
-
-    // Check Maven Central for the latest version:
-    // https://central.sonatype.com/artifact/com.topsort/topsort-kt
     implementation 'com.topsort:topsort-kt:2.0.1'
 }
 ```
 
-Ensure your project is configured to use at least Java 11:
+The library is distributed via [Maven Central](https://central.sonatype.com/artifact/com.topsort/topsort-kt).
 
-```gradle
-android {
-    // Other configurations...
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
-    }
-    kotlinOptions {
-        jvmTarget = '11'
-    }
-}
-```
+## Quick Start
 
-The library is distributed through Maven central, which is usually included by default in your repositories.
-You can also add it directly, if needed:
+### Setup
 
-```gradle
-repositories {
-    mavenCentral()
-}
-```
-
-## Usage/Examples
-
-#### Setup
-
-The following sample code shows how to setup the analytics library before reporting any event:
-
-##### Kotlin
+Initialize the SDK in your `Application` class:
 
 ```kotlin
-import android.app.Application
 import com.topsort.analytics.Analytics
 
-class KotlinApplication : Application() {
-
+class MyApplication : Application() {
     override fun onCreate() {
         super.onCreate()
-
-        // Either generate a unique session id here or hash an existing
-        // identifier. It should be consistent for
-        // each user (impression, click, purchase).
-
         Analytics.setup(
-            this,
-            "sessionId",
-            "bearerToken"
+            application = this,
+            opaqueUserId = "user-unique-id",
+            token = "your-api-token"
         )
     }
 }
 ```
 
-##### Java
-```java
-import android.app.Application;
-import com.topsort.analytics.Analytics;
+### Event Tracking
 
-public class JavaApplication extends Application {
-
-
-    @Override
-    public void onCreate() {
-        super.onCreate();
-
-        Analytics
-                .INSTANCE
-                .setup(this, "sessionId", "bearerToken");
-    }
-}
-
-```
-
-#### Reporting Events
-
-The following samples show how to report different events after setting up.
-
-The `Placement` constructor requires a `path` parameter (the URL path or deeplink for the current view). Other fields like `location`, `page`, `position`, `pageSize`, `productId`, `categoryIds`, and `searchQuery` are optional:
+#### Impressions & Clicks
 
 ```kotlin
-val placement = Placement(
-    path = "/search/results",
-    location = "position_1",
-    page = 1,
-    pageSize = 20
+// Promoted (from auction winner)
+Analytics.reportImpressionPromoted(
+    resolvedBidId = "auction-bid-id",
+    placement = Placement(path = "/search/results")
+)
+
+Analytics.reportClickPromoted(
+    resolvedBidId = "auction-bid-id",
+    placement = Placement(path = "/search/results")
+)
+
+// Organic (without auction)
+Analytics.reportImpressionOrganic(
+    entity = Entity(id = "product-123", type = EntityType.PRODUCT),
+    placement = Placement(path = "/category/electronics")
 )
 ```
 
-##### Promoted events (with resolvedBidId from auction)
+#### Purchases
 
 ```kotlin
-fun reportPromotedImpression() {
-    val placement = Placement(
-        path = "/search/results",
-        location = "position_1"
+Analytics.reportPurchase(
+    id = "order-123",
+    items = listOf(
+        PurchasedItem(
+            productId = "product-123",
+            quantity = 2,
+            unitPrice = 1295  // cents ($12.95)
+        )
     )
-
-    Analytics.reportImpressionPromoted(
-        resolvedBidId = "<The bid id from the auction winner>",
-        placement = placement
-    )
-}
-
-fun reportPromotedClick() {
-    val placement = Placement(
-        path = "/search/results",
-        location = "position_1"
-    )
-
-    Analytics.reportClickPromoted(
-        resolvedBidId = "<The bid id from the auction winner>",
-        placement = placement
-    )
-}
+)
 ```
 
-##### Organic events (with entity instead of resolvedBidId)
-
-```kotlin
-fun reportOrganicImpression() {
-    val placement = Placement(
-        path = "/search/results",
-        location = "position_1"
-    )
-
-    Analytics.reportImpressionOrganic(
-        entity = Entity(id = "productId", type = EntityType.PRODUCT),
-        placement = placement
-    )
-}
-
-fun reportOrganicClick() {
-    val placement = Placement(
-        path = "/search/results",
-        location = "position_1"
-    )
-
-    Analytics.reportClickOrganic(
-        entity = Entity(id = "productId", type = EntityType.PRODUCT),
-        placement = placement
-    )
-}
-```
-
-##### Purchase events
-
-```kotlin
-fun reportPurchase() {
-    val item = PurchasedItem(
-        productId = "productId",
-        quantity = 20,
-        unitPrice = 1295, // price in cents ($12.95)
-    )
-
-    Analytics.reportPurchase(
-        id = "orderId",
-        items = listOf(item)
-    )
-}
-```
-
-##### Page View events
-
-Track page views to understand user navigation patterns:
+#### Page Views
 
 ```kotlin
 import com.topsort.analytics.model.Page
 
-// Simple home page view
-Analytics.reportPageView(
-    page = Page.Factory.build(type = Page.TYPE_HOME)
-)
-
-// Product detail page with ID
+// Product detail page
 Analytics.reportPageView(
     page = Page.Factory.buildWithId(
         type = Page.TYPE_PDP,
@@ -209,122 +107,111 @@ Analytics.reportPageView(
     channel = "onsite"
 )
 
-// Search results page with query
-Analytics.reportPageView(
-    page = Page.Factory.buildWithId(
-        type = Page.TYPE_SEARCH,
-        pageId = "search-results",
-        value = "running shoes"
-    )
-)
-
-// Category page with hierarchy
+// Category with hierarchy
 Analytics.reportPageView(
     page = Page.Factory.buildWithValues(
         type = Page.TYPE_CATEGORY,
-        values = listOf("Electronics", "Phones", "Smartphones"),
-        pageId = "cat-smartphones"
+        values = listOf("Electronics", "Phones", "Smartphones")
+    )
+)
+
+// Search results
+Analytics.reportPageView(
+    page = Page.Factory.buildWithId(
+        type = Page.TYPE_SEARCH,
+        pageId = "search",
+        value = "running shoes"  // search query
     )
 )
 ```
 
-**Available page types:** `Page.TYPE_HOME`, `Page.TYPE_CATEGORY`, `Page.TYPE_PDP`, `Page.TYPE_SEARCH`, `Page.TYPE_CART`, `Page.TYPE_OTHER`
+**Page Types:** `TYPE_HOME`, `TYPE_CATEGORY`, `TYPE_PDP`, `TYPE_SEARCH`, `TYPE_CART`, `TYPE_OTHER`
 
-**Optional parameters:**
-- `deviceType`: `"desktop"` or `"mobile"`
-- `channel`: `"onsite"`, `"offsite"`, or `"instore"`
+### Auctions
 
-## Banner Auctions with Error Handling and Callbacks
+```kotlin
+import com.topsort.analytics.model.auctions.*
+import com.topsort.analytics.service.TopsortAuctionsHttpService
 
-The library provides comprehensive support for banner auctions with robust error handling and callbacks:
+val config = AuctionConfig.ProductIds(
+    numSlots = 3,
+    ids = listOf("product-1", "product-2", "product-3")
+)
 
-### Kotlin
+val auction = Auction.fromConfig(config)
+val request = AuctionRequest(auctions = listOf(auction))
+
+// Coroutine
+lifecycleScope.launch {
+    val response = TopsortAuctionsHttpService.runAuctions(request)
+    response.results.forEach { result ->
+        result.winners.forEach { winner ->
+            // Use winner.resolvedBidId for tracking
+        }
+    }
+}
+
+// Synchronous (not on main thread)
+val response = TopsortAuctionsHttpService.runAuctionsSync(request)
+```
+
+### Banner Ads
 
 ```kotlin
 import com.topsort.analytics.banners.BannerConfig
 import com.topsort.analytics.banners.BannerView
-import com.topsort.analytics.model.auctions.AuctionError
-import com.topsort.analytics.model.auctions.EntityType
 
-// In your Activity or Fragment
 val bannerView = findViewById<BannerView>(R.id.banner_view)
 
-// Configure error handling and callbacks
-bannerView.onError { throwable: Throwable ->
-    Log.e("BannerDemo", "Error loading banner", throwable)
-    // Handle general errors
-}
+// Callbacks
+bannerView.onImageLoad { /* Banner loaded */ }
+bannerView.onNoWinners { /* No ads available */ }
+bannerView.onError { throwable -> /* Handle error */ }
+bannerView.onAuctionError { error -> /* Handle auction error */ }
 
-bannerView.onAuctionError { error: AuctionError ->
-    when (error) {
-        is AuctionError.HttpError -> Log.e("BannerDemo", "Network error", error)
-        is AuctionError.DeserializationError -> Log.e("BannerDemo", "Failed to parse response", error)
-        is AuctionError.EmptyResponse -> Log.e("BannerDemo", "Empty response from server")
-        else -> Log.e("BannerDemo", "Other auction error", error)
-    }
-    // Handle auction-specific errors
-}
-
-bannerView.onNoWinners {
-    Log.d("BannerDemo", "No winners for this auction")
-    // Handle case when auction returns no winners
-}
-
-bannerView.onImageLoad {
-    Log.d("BannerDemo", "Banner image loaded successfully")
-    // Execute code after successful image load
-}
-
-// Run the auction
+// Run auction and display
 lifecycleScope.launch {
-    // Configure and run the auction
     val config = BannerConfig.LandingPage(
-        slotId = "your-slot-id", 
+        slotId = "home-banner",
         ids = listOf("product-1", "product-2")
     )
-    
-    bannerView.setup(
-        config = config,
-        path = "product-page",
-        location = "top-banner"
-    ) { id, type ->
-        // Handle banner click
-        when (type) {
-            EntityType.PRODUCT -> openProductPage(id)
-            EntityType.VENDOR -> openVendorPage(id)
-            else -> openUrl(id)
-        }
+
+    bannerView.setup(config, path = "home", location = "top") { id, type ->
+        // Handle click
     }
 }
 ```
 
 ## Error Handling
 
-The library now provides detailed error handling through the AuctionError sealed class:
-
 ```kotlin
 when (error) {
-    is AuctionError.HttpError -> // Handle HTTP errors
-    is AuctionError.DeserializationError -> // Handle deserialization errors
-    is AuctionError.SerializationError -> // Handle serialization errors
-    is AuctionError.EmptyResponse -> // Handle empty responses
-    is AuctionError.InvalidNumberAuctions -> // Handle invalid auction count
+    is AuctionError.HttpError -> // Network/server error
+    is AuctionError.DeserializationError -> // Parse error
+    is AuctionError.EmptyResponse -> // No response
+    is AuctionError.InvalidNumberAuctions -> // Invalid auction count (1-5)
+    else -> // Other errors
 }
 ```
 
-## Testing Support
+## Testing
 
-For testing, the library includes helper classes to mock auction services:
+Mock the auction service for unit tests:
 
 ```kotlin
-// In your test
 val mockService = MockAuctionsHttpService()
 TopsortAuctionsHttpService.setMockService(mockService)
 
-// After test
+// Run tests...
+
 TopsortAuctionsHttpService.resetToDefaultService()
 ```
 
-For more details, refer to the code samples and API documentation.
+## Documentation
 
-[1]: https://github.com/Topsort/topsort.kt/blob/main/LICENSE
+- [API Documentation](https://docs.topsort.com)
+- [Topsort Dashboard](https://app.topsort.com)
+
+## License
+
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,217 +1,283 @@
-# topsort.kt
+# Topsort kotlin library
 
-[![Build](https://github.com/Topsort/topsort.kt/actions/workflows/tests.yaml/badge.svg)](https://github.com/Topsort/topsort.kt/actions/workflows/tests.yaml)
-[![Maven Central](https://img.shields.io/maven-central/v/com.topsort/topsort-kt.svg)](https://central.sonatype.com/artifact/com.topsort/topsort-kt)
-[![Kotlin](https://img.shields.io/badge/Kotlin-2.0+-7F52FF.svg?logo=kotlin&logoColor=white)](https://kotlinlang.org)
-[![Android API](https://img.shields.io/badge/API-24+-34A853.svg?logo=android&logoColor=white)](https://developer.android.com/about/versions/nougat)
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/Topsort/topsort.kt/blob/main/LICENSE)
+An Android library for interacting with the Topsort APIs. We provide support for sending events and running banner auctions with comprehensive error handling and callback support.
 
-Android SDK for [Topsort's](https://www.topsort.com) retail media platform. Provides auction execution, event tracking (impressions, clicks, purchases, page views), and banner ad components.
-
-## Features
-
-- **Auctions** - Run sponsored listing and banner auctions
-- **Event Tracking** - Report impressions, clicks, purchases, and page views
-- **Banner Ads** - Ready-to-use `BannerView` component with automatic tracking
-- **Offline Support** - Events are cached and delivered when connectivity returns
-- **Zero Configuration** - Sensible defaults with optional customization
+Licensed under [MIT][1].
 
 ## Requirements
 
-- Android API 24+ (Android 7.0 Nougat)
-- Java 11+
+- Minimum Java version: 11
+- Android SDK: 24+
+- `INTERNET` permission (add to your `AndroidManifest.xml` if not already present)
 
-## Installation
+## Installation / Getting started
 
-Add the dependency to your `build.gradle`:
+We recommend installing the library via Gradle.
+Simply add the dependency to your build.gradle file:
 
 ```gradle
 dependencies {
+    ...
+
+    // Check Maven Central for the latest version:
+    // https://central.sonatype.com/artifact/com.topsort/topsort-kt
     implementation 'com.topsort:topsort-kt:2.0.1'
 }
 ```
 
-The library is distributed via [Maven Central](https://central.sonatype.com/artifact/com.topsort/topsort-kt).
+Ensure your project is configured to use at least Java 11:
 
-## Quick Start
+```gradle
+android {
+    // Other configurations...
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
+    }
+    kotlinOptions {
+        jvmTarget = '11'
+    }
+}
+```
 
-### Setup
+The library is distributed through Maven central, which is usually included by default in your repositories.
+You can also add it directly, if needed:
 
-Initialize the SDK in your `Application` class:
+```gradle
+repositories {
+    mavenCentral()
+}
+```
+
+## Usage/Examples
+
+#### Setup
+
+The following sample code shows how to setup the analytics library before reporting any event:
+
+##### Kotlin
 
 ```kotlin
+import android.app.Application
 import com.topsort.analytics.Analytics
 
-class MyApplication : Application() {
+class KotlinApplication : Application() {
+
     override fun onCreate() {
         super.onCreate()
+
+        // Either generate a unique session id here or hash an existing
+        // identifier. It should be consistent for
+        // each user (impression, click, purchase).
+
         Analytics.setup(
-            application = this,
-            opaqueUserId = "user-unique-id",
-            token = "your-api-token"
+            this,
+            "sessionId",
+            "bearerToken"
         )
     }
 }
 ```
 
-### Event Tracking
+##### Java
+```java
+import android.app.Application;
+import com.topsort.analytics.Analytics;
 
-#### Impressions & Clicks
+public class JavaApplication extends Application {
 
-```kotlin
-// Promoted (from auction winner)
-Analytics.reportImpressionPromoted(
-    resolvedBidId = "auction-bid-id",
-    placement = Placement(path = "/search/results")
-)
 
-Analytics.reportClickPromoted(
-    resolvedBidId = "auction-bid-id",
-    placement = Placement(path = "/search/results")
-)
+    @Override
+    public void onCreate() {
+        super.onCreate();
 
-// Organic (without auction)
-Analytics.reportImpressionOrganic(
-    entity = Entity(id = "product-123", type = EntityType.PRODUCT),
-    placement = Placement(path = "/category/electronics")
-)
-```
-
-#### Purchases
-
-```kotlin
-Analytics.reportPurchase(
-    id = "order-123",
-    items = listOf(
-        PurchasedItem(
-            productId = "product-123",
-            quantity = 2,
-            unitPrice = 1295  // cents ($12.95)
-        )
-    )
-)
-```
-
-#### Page Views
-
-```kotlin
-import com.topsort.analytics.model.Page
-
-// Product detail page
-Analytics.reportPageView(
-    page = Page.Factory.buildWithId(
-        type = Page.TYPE_PDP,
-        pageId = "product-123"
-    ),
-    deviceType = "mobile",
-    channel = "onsite"
-)
-
-// Category with hierarchy
-Analytics.reportPageView(
-    page = Page.Factory.buildWithValues(
-        type = Page.TYPE_CATEGORY,
-        values = listOf("Electronics", "Phones", "Smartphones")
-    )
-)
-
-// Search results
-Analytics.reportPageView(
-    page = Page.Factory.buildWithId(
-        type = Page.TYPE_SEARCH,
-        pageId = "search",
-        value = "running shoes"  // search query
-    )
-)
-```
-
-**Page Types:** `TYPE_HOME`, `TYPE_CATEGORY`, `TYPE_PDP`, `TYPE_SEARCH`, `TYPE_CART`, `TYPE_OTHER`
-
-### Auctions
-
-```kotlin
-import com.topsort.analytics.model.auctions.*
-import com.topsort.analytics.service.TopsortAuctionsHttpService
-
-val config = AuctionConfig.ProductIds(
-    numSlots = 3,
-    ids = listOf("product-1", "product-2", "product-3")
-)
-
-val auction = Auction.fromConfig(config)
-val request = AuctionRequest(auctions = listOf(auction))
-
-// Coroutine
-lifecycleScope.launch {
-    val response = TopsortAuctionsHttpService.runAuctions(request)
-    response.results.forEach { result ->
-        result.winners.forEach { winner ->
-            // Use winner.resolvedBidId for tracking
-        }
+        Analytics
+                .INSTANCE
+                .setup(this, "sessionId", "bearerToken");
     }
 }
 
-// Synchronous (not on main thread)
-val response = TopsortAuctionsHttpService.runAuctionsSync(request)
 ```
 
-### Banner Ads
+#### Reporting Events
+
+The following samples show how to report different events after setting up.
+
+The `Placement` constructor requires a `path` parameter (the URL path or deeplink for the current view). Other fields like `location`, `page`, `position`, `pageSize`, `productId`, `categoryIds`, and `searchQuery` are optional:
+
+```kotlin
+val placement = Placement(
+    path = "/search/results",
+    location = "position_1",
+    page = 1,
+    pageSize = 20
+)
+```
+
+##### Promoted events (with resolvedBidId from auction)
+
+```kotlin
+fun reportPromotedImpression() {
+    val placement = Placement(
+        path = "/search/results",
+        location = "position_1"
+    )
+
+    Analytics.reportImpressionPromoted(
+        resolvedBidId = "<The bid id from the auction winner>",
+        placement = placement
+    )
+}
+
+fun reportPromotedClick() {
+    val placement = Placement(
+        path = "/search/results",
+        location = "position_1"
+    )
+
+    Analytics.reportClickPromoted(
+        resolvedBidId = "<The bid id from the auction winner>",
+        placement = placement
+    )
+}
+```
+
+##### Organic events (with entity instead of resolvedBidId)
+
+```kotlin
+fun reportOrganicImpression() {
+    val placement = Placement(
+        path = "/search/results",
+        location = "position_1"
+    )
+
+    Analytics.reportImpressionOrganic(
+        entity = Entity(id = "productId", type = EntityType.PRODUCT),
+        placement = placement
+    )
+}
+
+fun reportOrganicClick() {
+    val placement = Placement(
+        path = "/search/results",
+        location = "position_1"
+    )
+
+    Analytics.reportClickOrganic(
+        entity = Entity(id = "productId", type = EntityType.PRODUCT),
+        placement = placement
+    )
+}
+```
+
+##### Purchase events
+
+```kotlin
+fun reportPurchase() {
+    val item = PurchasedItem(
+        productId = "productId",
+        quantity = 20,
+        unitPrice = 1295, // price in cents ($12.95)
+    )
+
+    Analytics.reportPurchase(
+        id = "orderId",
+        items = listOf(item)
+    )
+}
+```
+
+## Banner Auctions with Error Handling and Callbacks
+
+The library provides comprehensive support for banner auctions with robust error handling and callbacks:
+
+### Kotlin
 
 ```kotlin
 import com.topsort.analytics.banners.BannerConfig
 import com.topsort.analytics.banners.BannerView
+import com.topsort.analytics.model.auctions.AuctionError
+import com.topsort.analytics.model.auctions.EntityType
 
+// In your Activity or Fragment
 val bannerView = findViewById<BannerView>(R.id.banner_view)
 
-// Callbacks
-bannerView.onImageLoad { /* Banner loaded */ }
-bannerView.onNoWinners { /* No ads available */ }
-bannerView.onError { throwable -> /* Handle error */ }
-bannerView.onAuctionError { error -> /* Handle auction error */ }
+// Configure error handling and callbacks
+bannerView.onError { throwable: Throwable ->
+    Log.e("BannerDemo", "Error loading banner", throwable)
+    // Handle general errors
+}
 
-// Run auction and display
+bannerView.onAuctionError { error: AuctionError ->
+    when (error) {
+        is AuctionError.HttpError -> Log.e("BannerDemo", "Network error", error)
+        is AuctionError.DeserializationError -> Log.e("BannerDemo", "Failed to parse response", error)
+        is AuctionError.EmptyResponse -> Log.e("BannerDemo", "Empty response from server")
+        else -> Log.e("BannerDemo", "Other auction error", error)
+    }
+    // Handle auction-specific errors
+}
+
+bannerView.onNoWinners {
+    Log.d("BannerDemo", "No winners for this auction")
+    // Handle case when auction returns no winners
+}
+
+bannerView.onImageLoad {
+    Log.d("BannerDemo", "Banner image loaded successfully")
+    // Execute code after successful image load
+}
+
+// Run the auction
 lifecycleScope.launch {
+    // Configure and run the auction
     val config = BannerConfig.LandingPage(
-        slotId = "home-banner",
+        slotId = "your-slot-id", 
         ids = listOf("product-1", "product-2")
     )
-
-    bannerView.setup(config, path = "home", location = "top") { id, type ->
-        // Handle click
+    
+    bannerView.setup(
+        config = config,
+        path = "product-page",
+        location = "top-banner"
+    ) { id, type ->
+        // Handle banner click
+        when (type) {
+            EntityType.PRODUCT -> openProductPage(id)
+            EntityType.VENDOR -> openVendorPage(id)
+            else -> openUrl(id)
+        }
     }
 }
 ```
 
 ## Error Handling
 
+The library now provides detailed error handling through the AuctionError sealed class:
+
 ```kotlin
 when (error) {
-    is AuctionError.HttpError -> // Network/server error
-    is AuctionError.DeserializationError -> // Parse error
-    is AuctionError.EmptyResponse -> // No response
-    is AuctionError.InvalidNumberAuctions -> // Invalid auction count (1-5)
-    else -> // Other errors
+    is AuctionError.HttpError -> // Handle HTTP errors
+    is AuctionError.DeserializationError -> // Handle deserialization errors
+    is AuctionError.SerializationError -> // Handle serialization errors
+    is AuctionError.EmptyResponse -> // Handle empty responses
+    is AuctionError.InvalidNumberAuctions -> // Handle invalid auction count
 }
 ```
 
-## Testing
+## Testing Support
 
-Mock the auction service for unit tests:
+For testing, the library includes helper classes to mock auction services:
 
 ```kotlin
+// In your test
 val mockService = MockAuctionsHttpService()
 TopsortAuctionsHttpService.setMockService(mockService)
 
-// Run tests...
-
+// After test
 TopsortAuctionsHttpService.resetToDefaultService()
 ```
 
-## Documentation
+For more details, refer to the code samples and API documentation.
 
-- [API Documentation](https://docs.topsort.com)
-- [Topsort Dashboard](https://app.topsort.com)
-
-## License
-
-[MIT](LICENSE)
+[1]: https://github.com/Topsort/topsort.kt/blob/main/LICENSE

--- a/TopsortAnalytics/api/TopsortAnalytics.api
+++ b/TopsortAnalytics/api/TopsortAnalytics.api
@@ -375,55 +375,6 @@ public final class com/topsort/analytics/model/Page$Factory {
 	public final fun fromJsonObject (Lorg/json/JSONObject;)Lcom/topsort/analytics/model/Page;
 }
 
-public final class com/topsort/analytics/model/PageView : com/topsort/analytics/model/JsonSerializable {
-	public synthetic fun <init> (Lcom/topsort/analytics/model/Page;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/topsort/analytics/model/Page;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Ljava/lang/String;
-	public final fun copy (Lcom/topsort/analytics/model/Page;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/topsort/analytics/model/PageView;
-	public static synthetic fun copy$default (Lcom/topsort/analytics/model/PageView;Lcom/topsort/analytics/model/Page;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/topsort/analytics/model/PageView;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannel ()Ljava/lang/String;
-	public final fun getDeviceType ()Ljava/lang/String;
-	public final fun getId ()Ljava/lang/String;
-	public final fun getOccurredAt ()Ljava/lang/String;
-	public final fun getOpaqueUserId ()Ljava/lang/String;
-	public final fun getPage ()Lcom/topsort/analytics/model/Page;
-	public fun hashCode ()I
-	public fun toJsonObject ()Lorg/json/JSONObject;
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/topsort/analytics/model/PageView$Factory {
-	public static final field INSTANCE Lcom/topsort/analytics/model/PageView$Factory;
-	public final fun build (Lcom/topsort/analytics/model/Page;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/topsort/analytics/model/PageView;
-	public final fun build (Lcom/topsort/analytics/model/Page;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/topsort/analytics/model/PageView;
-	public final fun build (Lcom/topsort/analytics/model/Page;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/topsort/analytics/model/PageView;
-	public static synthetic fun build$default (Lcom/topsort/analytics/model/PageView$Factory;Lcom/topsort/analytics/model/Page;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/topsort/analytics/model/PageView;
-	public final fun fromJsonArray (Lorg/json/JSONArray;)Ljava/util/List;
-	public final fun fromJsonObject (Lorg/json/JSONObject;)Lcom/topsort/analytics/model/PageView;
-}
-
-public final class com/topsort/analytics/model/PageViewEvent {
-	public static final field Companion Lcom/topsort/analytics/model/PageViewEvent$Companion;
-	public fun <init> (Ljava/util/List;)V
-	public final fun component1 ()Ljava/util/List;
-	public final fun copy (Ljava/util/List;)Lcom/topsort/analytics/model/PageViewEvent;
-	public static synthetic fun copy$default (Lcom/topsort/analytics/model/PageViewEvent;Ljava/util/List;ILjava/lang/Object;)Lcom/topsort/analytics/model/PageViewEvent;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getPageviews ()Ljava/util/List;
-	public fun hashCode ()I
-	public final fun toJsonObject ()Lorg/json/JSONObject;
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/topsort/analytics/model/PageViewEvent$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/topsort/analytics/model/PageViewEvent;
-}
-
 public final class com/topsort/analytics/model/Placement {
 	public static final field Companion Lcom/topsort/analytics/model/Placement$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)V

--- a/TopsortAnalytics/api/TopsortAnalytics.api
+++ b/TopsortAnalytics/api/TopsortAnalytics.api
@@ -5,6 +5,7 @@ public final class com/topsort/analytics/Analytics : com/topsort/analytics/Topso
 	public fun reportImpressionOrganic (Lcom/topsort/analytics/model/Entity;Lcom/topsort/analytics/model/Placement;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public fun reportImpressionPromoted (Ljava/lang/String;Lcom/topsort/analytics/model/Placement;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public final fun reportImpressions (Ljava/util/List;)V
+	public fun reportPageView (Lcom/topsort/analytics/model/Page;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public fun reportPurchase (Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public final fun setup (Landroid/app/Application;Ljava/lang/String;Ljava/lang/String;)V
 }
@@ -18,6 +19,8 @@ public abstract interface class com/topsort/analytics/TopsortAnalytics {
 	public static synthetic fun reportImpressionOrganic$default (Lcom/topsort/analytics/TopsortAnalytics;Lcom/topsort/analytics/model/Entity;Lcom/topsort/analytics/model/Placement;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 	public abstract fun reportImpressionPromoted (Ljava/lang/String;Lcom/topsort/analytics/model/Placement;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public static synthetic fun reportImpressionPromoted$default (Lcom/topsort/analytics/TopsortAnalytics;Ljava/lang/String;Lcom/topsort/analytics/model/Placement;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
+	public abstract fun reportPageView (Lcom/topsort/analytics/model/Page;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public static synthetic fun reportPageView$default (Lcom/topsort/analytics/TopsortAnalytics;Lcom/topsort/analytics/model/Page;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 	public abstract fun reportPurchase (Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public static synthetic fun reportPurchase$default (Lcom/topsort/analytics/TopsortAnalytics;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 }
@@ -27,6 +30,7 @@ public final class com/topsort/analytics/TopsortAnalytics$DefaultImpls {
 	public static synthetic fun reportClickPromoted$default (Lcom/topsort/analytics/TopsortAnalytics;Ljava/lang/String;Lcom/topsort/analytics/model/Placement;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 	public static synthetic fun reportImpressionOrganic$default (Lcom/topsort/analytics/TopsortAnalytics;Lcom/topsort/analytics/model/Entity;Lcom/topsort/analytics/model/Placement;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 	public static synthetic fun reportImpressionPromoted$default (Lcom/topsort/analytics/TopsortAnalytics;Ljava/lang/String;Lcom/topsort/analytics/model/Placement;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
+	public static synthetic fun reportPageView$default (Lcom/topsort/analytics/TopsortAnalytics;Lcom/topsort/analytics/model/Page;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 	public static synthetic fun reportPurchase$default (Lcom/topsort/analytics/TopsortAnalytics;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 }
 
@@ -266,6 +270,7 @@ public final class com/topsort/analytics/model/Event$Companion {
 public final class com/topsort/analytics/model/EventType : java/lang/Enum {
 	public static final field Click Lcom/topsort/analytics/model/EventType;
 	public static final field Impression Lcom/topsort/analytics/model/EventType;
+	public static final field PageView Lcom/topsort/analytics/model/EventType;
 	public static final field Purchase Lcom/topsort/analytics/model/EventType;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/topsort/analytics/model/EventType;
@@ -327,6 +332,95 @@ public final class com/topsort/analytics/model/ImpressionEvent$Companion {
 
 public abstract interface class com/topsort/analytics/model/JsonSerializable {
 	public abstract fun toJsonObject ()Lorg/json/JSONObject;
+}
+
+public final class com/topsort/analytics/model/Page : com/topsort/analytics/model/JsonSerializable {
+	public static final field Companion Lcom/topsort/analytics/model/Page$Companion;
+	public static final field TYPE_CART Ljava/lang/String;
+	public static final field TYPE_CATEGORY Ljava/lang/String;
+	public static final field TYPE_HOME Ljava/lang/String;
+	public static final field TYPE_OTHER Ljava/lang/String;
+	public static final field TYPE_PDP Ljava/lang/String;
+	public static final field TYPE_SEARCH Ljava/lang/String;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lcom/topsort/analytics/model/Page;
+	public static synthetic fun copy$default (Lcom/topsort/analytics/model/Page;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lcom/topsort/analytics/model/Page;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPageId ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/String;
+	public final fun getValues ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toJsonObject ()Lorg/json/JSONObject;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/topsort/analytics/model/Page$Companion {
+}
+
+public final class com/topsort/analytics/model/Page$Factory {
+	public static final field INSTANCE Lcom/topsort/analytics/model/Page$Factory;
+	public final fun build (Ljava/lang/String;)Lcom/topsort/analytics/model/Page;
+	public final fun buildWithId (Ljava/lang/String;Ljava/lang/String;)Lcom/topsort/analytics/model/Page;
+	public final fun buildWithId (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/topsort/analytics/model/Page;
+	public static synthetic fun buildWithId$default (Lcom/topsort/analytics/model/Page$Factory;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/topsort/analytics/model/Page;
+	public final fun buildWithValues (Ljava/lang/String;Ljava/util/List;)Lcom/topsort/analytics/model/Page;
+	public final fun buildWithValues (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)Lcom/topsort/analytics/model/Page;
+	public static synthetic fun buildWithValues$default (Lcom/topsort/analytics/model/Page$Factory;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lcom/topsort/analytics/model/Page;
+	public final fun fromJsonObject (Lorg/json/JSONObject;)Lcom/topsort/analytics/model/Page;
+}
+
+public final class com/topsort/analytics/model/PageView : com/topsort/analytics/model/JsonSerializable {
+	public synthetic fun <init> (Lcom/topsort/analytics/model/Page;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/topsort/analytics/model/Page;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Lcom/topsort/analytics/model/Page;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/topsort/analytics/model/PageView;
+	public static synthetic fun copy$default (Lcom/topsort/analytics/model/PageView;Lcom/topsort/analytics/model/Page;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/topsort/analytics/model/PageView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChannel ()Ljava/lang/String;
+	public final fun getDeviceType ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getOccurredAt ()Ljava/lang/String;
+	public final fun getOpaqueUserId ()Ljava/lang/String;
+	public final fun getPage ()Lcom/topsort/analytics/model/Page;
+	public fun hashCode ()I
+	public fun toJsonObject ()Lorg/json/JSONObject;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/topsort/analytics/model/PageView$Factory {
+	public static final field INSTANCE Lcom/topsort/analytics/model/PageView$Factory;
+	public final fun build (Lcom/topsort/analytics/model/Page;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/topsort/analytics/model/PageView;
+	public final fun build (Lcom/topsort/analytics/model/Page;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/topsort/analytics/model/PageView;
+	public final fun build (Lcom/topsort/analytics/model/Page;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/topsort/analytics/model/PageView;
+	public static synthetic fun build$default (Lcom/topsort/analytics/model/PageView$Factory;Lcom/topsort/analytics/model/Page;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/topsort/analytics/model/PageView;
+	public final fun fromJsonArray (Lorg/json/JSONArray;)Ljava/util/List;
+	public final fun fromJsonObject (Lorg/json/JSONObject;)Lcom/topsort/analytics/model/PageView;
+}
+
+public final class com/topsort/analytics/model/PageViewEvent {
+	public static final field Companion Lcom/topsort/analytics/model/PageViewEvent$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lcom/topsort/analytics/model/PageViewEvent;
+	public static synthetic fun copy$default (Lcom/topsort/analytics/model/PageViewEvent;Ljava/util/List;ILjava/lang/Object;)Lcom/topsort/analytics/model/PageViewEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPageviews ()Ljava/util/List;
+	public fun hashCode ()I
+	public final fun toJsonObject ()Lorg/json/JSONObject;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/topsort/analytics/model/PageViewEvent$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/topsort/analytics/model/PageViewEvent;
 }
 
 public final class com/topsort/analytics/model/Placement {

--- a/TopsortAnalytics/api/TopsortAnalytics.api
+++ b/TopsortAnalytics/api/TopsortAnalytics.api
@@ -19,7 +19,7 @@ public abstract interface class com/topsort/analytics/TopsortAnalytics {
 	public static synthetic fun reportImpressionOrganic$default (Lcom/topsort/analytics/TopsortAnalytics;Lcom/topsort/analytics/model/Entity;Lcom/topsort/analytics/model/Placement;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 	public abstract fun reportImpressionPromoted (Ljava/lang/String;Lcom/topsort/analytics/model/Placement;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public static synthetic fun reportImpressionPromoted$default (Lcom/topsort/analytics/TopsortAnalytics;Ljava/lang/String;Lcom/topsort/analytics/model/Placement;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
-	public abstract fun reportPageView (Lcom/topsort/analytics/model/Page;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun reportPageView (Lcom/topsort/analytics/model/Page;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public static synthetic fun reportPageView$default (Lcom/topsort/analytics/TopsortAnalytics;Lcom/topsort/analytics/model/Page;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 	public abstract fun reportPurchase (Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public static synthetic fun reportPurchase$default (Lcom/topsort/analytics/TopsortAnalytics;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
@@ -30,6 +30,7 @@ public final class com/topsort/analytics/TopsortAnalytics$DefaultImpls {
 	public static synthetic fun reportClickPromoted$default (Lcom/topsort/analytics/TopsortAnalytics;Ljava/lang/String;Lcom/topsort/analytics/model/Placement;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 	public static synthetic fun reportImpressionOrganic$default (Lcom/topsort/analytics/TopsortAnalytics;Lcom/topsort/analytics/model/Entity;Lcom/topsort/analytics/model/Placement;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 	public static synthetic fun reportImpressionPromoted$default (Lcom/topsort/analytics/TopsortAnalytics;Ljava/lang/String;Lcom/topsort/analytics/model/Placement;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
+	public static fun reportPageView (Lcom/topsort/analytics/TopsortAnalytics;Lcom/topsort/analytics/model/Page;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public static synthetic fun reportPageView$default (Lcom/topsort/analytics/TopsortAnalytics;Lcom/topsort/analytics/model/Page;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 	public static synthetic fun reportPurchase$default (Lcom/topsort/analytics/TopsortAnalytics;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 }

--- a/TopsortAnalytics/api/TopsortAnalytics.api
+++ b/TopsortAnalytics/api/TopsortAnalytics.api
@@ -336,7 +336,12 @@ public abstract interface class com/topsort/analytics/model/JsonSerializable {
 }
 
 public final class com/topsort/analytics/model/Page : com/topsort/analytics/model/JsonSerializable {
+	public static final field CHANNEL_INSTORE Ljava/lang/String;
+	public static final field CHANNEL_OFFSITE Ljava/lang/String;
+	public static final field CHANNEL_ONSITE Ljava/lang/String;
 	public static final field Companion Lcom/topsort/analytics/model/Page$Companion;
+	public static final field DEVICE_TYPE_DESKTOP Ljava/lang/String;
+	public static final field DEVICE_TYPE_MOBILE Ljava/lang/String;
 	public static final field TYPE_CART Ljava/lang/String;
 	public static final field TYPE_CATEGORY Ljava/lang/String;
 	public static final field TYPE_HOME Ljava/lang/String;

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/Analytics.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/Analytics.kt
@@ -19,6 +19,9 @@ import com.topsort.analytics.model.Entity
 import com.topsort.analytics.model.EventType
 import com.topsort.analytics.model.Impression
 import com.topsort.analytics.model.ImpressionEvent
+import com.topsort.analytics.model.Page
+import com.topsort.analytics.model.PageView
+import com.topsort.analytics.model.PageViewEvent
 import com.topsort.analytics.model.Placement
 import com.topsort.analytics.model.Purchase
 import com.topsort.analytics.model.PurchaseEvent
@@ -185,6 +188,36 @@ object Analytics : TopsortAnalytics {
 
         val recordId = Cache.storePurchase(purchaseEvent)
         enqueueEventRequest(recordId, EventType.Purchase)
+    }
+
+    override fun reportPageView(
+        page: Page,
+        opaqueUserId: String?,
+        id: String?,
+        occurredAt: String?,
+        deviceType: String?,
+        channel: String?,
+    ) {
+        if (!assertSetup()) {
+            Log.e(LOG_TAG, INVALID_CONFIG_ERROR_MESSAGE)
+            return
+        }
+
+        val pageViewEvent = PageViewEvent(
+            pageviews = listOf(
+                PageView.Factory.build(
+                    page = page,
+                    occurredAt = occurredAt ?: eventTime(),
+                    opaqueUserId = opaqueUserId ?: session!!.opaqueUserId,
+                    id = id ?: randomId(),
+                    deviceType = deviceType,
+                    channel = channel,
+                ),
+            ),
+        )
+
+        val recordId = Cache.storePageView(pageViewEvent)
+        enqueueEventRequest(recordId, EventType.PageView)
     }
 
     /**

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/Cache.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/Cache.kt
@@ -8,6 +8,7 @@ import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
 import com.topsort.analytics.model.ClickEvent
 import com.topsort.analytics.model.ImpressionEvent
+import com.topsort.analytics.model.PageViewEvent
 import com.topsort.analytics.model.PurchaseEvent
 import java.util.Locale
 
@@ -160,6 +161,22 @@ internal object Cache {
 
     fun readPurchase(recordId: Long): PurchaseEvent? {
         return PurchaseEvent.fromJson(readEvent(recordId))
+    }
+
+    fun storePageView(
+        pageViewEvent: PageViewEvent
+    ): Long {
+        val json = pageViewEvent.toJsonObject().toString()
+        preferences
+            .edit()
+            .putString(nextRecordKey(), json)
+            .apply()
+
+        return recentRecordId
+    }
+
+    fun readPageView(recordId: Long): PageViewEvent? {
+        return PageViewEvent.fromJson(readEvent(recordId))
     }
 
     fun deleteEvent(recordId: Long) {

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/TopsortAnalytics.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/TopsortAnalytics.kt
@@ -106,5 +106,8 @@ interface TopsortAnalytics {
         occurredAt: String? = null,
         deviceType: String? = null,
         channel: String? = null,
-    )
+    ) {
+        // Default empty implementation to maintain backward compatibility
+        // for existing TopsortAnalytics interface implementors.
+    }
 }

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/TopsortAnalytics.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/TopsortAnalytics.kt
@@ -1,6 +1,7 @@
 package com.topsort.analytics
 
 import com.topsort.analytics.model.Entity
+import com.topsort.analytics.model.Page
 import com.topsort.analytics.model.Placement
 import com.topsort.analytics.model.PurchasedItem
 
@@ -86,5 +87,24 @@ interface TopsortAnalytics {
         id: String,
         opaqueUserId: String? = null,
         occurredAt: String? = null,
+    )
+
+    /**
+     * Reports a page view event.
+     *
+     * @param page The page being viewed
+     * @param opaqueUserId The opaque user ID which allows correlating user activity.
+     * @param id The marketplace's unique ID for this page view event
+     * @param occurredAt RFC3339 formatted timestamp including UTC offset. Defaults to DateTime() when null
+     * @param deviceType Optional device type ("desktop" or "mobile")
+     * @param channel Optional channel ("onsite", "offsite", or "instore")
+     */
+    fun reportPageView(
+        page: Page,
+        opaqueUserId: String? = null,
+        id: String? = null,
+        occurredAt: String? = null,
+        deviceType: String? = null,
+        channel: String? = null,
     )
 }

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/model/EventType.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/model/EventType.kt
@@ -4,5 +4,6 @@ enum class EventType {
 
     Impression,
     Click,
-    Purchase
+    Purchase,
+    PageView,
 }

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/model/Page.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/model/Page.kt
@@ -154,5 +154,17 @@ data class Page private constructor(
         const val TYPE_SEARCH = "search"
         const val TYPE_CART = "cart"
         const val TYPE_OTHER = "other"
+
+        /** Device type constant for desktop devices */
+        const val DEVICE_TYPE_DESKTOP = "desktop"
+        /** Device type constant for mobile devices */
+        const val DEVICE_TYPE_MOBILE = "mobile"
+
+        /** Channel constant for onsite events */
+        const val CHANNEL_ONSITE = "onsite"
+        /** Channel constant for offsite events */
+        const val CHANNEL_OFFSITE = "offsite"
+        /** Channel constant for in-store events */
+        const val CHANNEL_INSTORE = "instore"
     }
 }

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/model/Page.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/model/Page.kt
@@ -11,6 +11,12 @@ import org.json.JSONObject
  * - [Factory.build] for simple page types
  * - [Factory.buildWithId] for pages with an identifier
  * - [Factory.buildWithValues] for pages with multiple values (e.g., category paths)
+ *
+ * **JSON Serialization Note:** Both [value] (single string) and [values] (list) serialize
+ * to the same JSON key `"value"`. The API distinguishes between them by JSON type:
+ * - Single value: `"value": "search query"`
+ * - Multiple values: `"value": ["Electronics", "Phones"]`
+ * This is intentional per the Topsort API contract.
  */
 data class Page private constructor(
     /**

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/model/Page.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/model/Page.kt
@@ -1,0 +1,147 @@
+package com.topsort.analytics.model
+
+import com.topsort.analytics.core.getStringOrNull
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Represents the page context where an event occurred.
+ *
+ * Use the [Factory] methods to create instances:
+ * - [Factory.build] for simple page types
+ * - [Factory.buildWithId] for pages with an identifier
+ * - [Factory.buildWithValues] for pages with multiple values (e.g., category paths)
+ */
+data class Page private constructor(
+    /**
+     * The type of page. Typically one of: "home", "category", "PDP", "search", "cart", "other".
+     */
+    val type: String,
+
+    /**
+     * Optional page identifier.
+     */
+    val pageId: String? = null,
+
+    /**
+     * Optional single value associated with the page (e.g., search query, product ID).
+     * Mutually exclusive with [values].
+     */
+    val value: String? = null,
+
+    /**
+     * Optional list of values associated with the page (e.g., category hierarchy).
+     * Mutually exclusive with [value].
+     */
+    val values: List<String>? = null,
+) : JsonSerializable {
+
+    init {
+        require(!(value != null && values != null)) {
+            "Page cannot have both 'value' and 'values' set. They are mutually exclusive."
+        }
+    }
+
+    override fun toJsonObject(): JSONObject {
+        return JSONObject().apply {
+            put("type", type)
+            pageId?.let { put("pageId", it) }
+            value?.let { put("value", it) }
+            values?.let { put("value", JSONArray(it)) }
+        }
+    }
+
+    object Factory {
+
+        /**
+         * Build a page with just a type.
+         *
+         * @param type The page type (e.g., "home", "cart", "other")
+         */
+        fun build(type: String): Page {
+            return Page(type = type)
+        }
+
+        /**
+         * Build a page with a type and page ID.
+         *
+         * @param type The page type
+         * @param pageId The page identifier
+         * @param value Optional single value
+         */
+        @JvmOverloads
+        fun buildWithId(
+            type: String,
+            pageId: String,
+            value: String? = null,
+        ): Page {
+            return Page(
+                type = type,
+                pageId = pageId,
+                value = value,
+            )
+        }
+
+        /**
+         * Build a page with multiple values (e.g., category hierarchy).
+         *
+         * @param type The page type
+         * @param pageId Optional page identifier
+         * @param values List of values (e.g., category path)
+         */
+        @JvmOverloads
+        fun buildWithValues(
+            type: String,
+            values: List<String>,
+            pageId: String? = null,
+        ): Page {
+            return Page(
+                type = type,
+                pageId = pageId,
+                values = values,
+            )
+        }
+
+        fun fromJsonObject(json: JSONObject): Page {
+            val type = json.getString("type")
+            val pageId = json.getStringOrNull("pageId")
+
+            // Handle value which can be string or array
+            val valueObj = json.opt("value")
+            val value: String?
+            val values: List<String>?
+
+            when (valueObj) {
+                is String -> {
+                    value = valueObj
+                    values = null
+                }
+                is JSONArray -> {
+                    value = null
+                    values = (0 until valueObj.length()).map { valueObj.getString(it) }
+                }
+                else -> {
+                    value = null
+                    values = null
+                }
+            }
+
+            return Page(
+                type = type,
+                pageId = pageId,
+                value = value,
+                values = values,
+            )
+        }
+    }
+
+    companion object {
+        /** Page type constants for convenience */
+        const val TYPE_HOME = "home"
+        const val TYPE_CATEGORY = "category"
+        const val TYPE_PDP = "PDP"
+        const val TYPE_SEARCH = "search"
+        const val TYPE_CART = "cart"
+        const val TYPE_OTHER = "other"
+    }
+}

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/model/Page.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/model/Page.kt
@@ -142,9 +142,14 @@ data class Page private constructor(
     }
 
     companion object {
-        /** Page type constants for convenience */
+        /**
+         * Page type constants matching the Topsort API contract.
+         * Note: TYPE_PDP is uppercase ("PDP") per the API specification,
+         * while other types are lowercase.
+         */
         const val TYPE_HOME = "home"
         const val TYPE_CATEGORY = "category"
+        /** Product Detail Page - uppercase per API contract */
         const val TYPE_PDP = "PDP"
         const val TYPE_SEARCH = "search"
         const val TYPE_CART = "cart"

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/model/PageViewEvent.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/model/PageViewEvent.kt
@@ -1,0 +1,134 @@
+package com.topsort.analytics.model
+
+import com.topsort.analytics.core.getListFromJsonArray
+import com.topsort.analytics.core.getStringOrNull
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Event representing a page view.
+ */
+data class PageViewEvent(
+    val pageviews: List<PageView>,
+) {
+    fun toJsonObject(): JSONObject {
+        val array = JSONArray()
+        pageviews.indices.map {
+            array.put(it, pageviews[it].toJsonObject())
+        }
+        return JSONObject().put("pageviews", array)
+    }
+
+    companion object {
+        fun fromJson(json: String?): PageViewEvent? {
+            if (json == null) return null
+            val array = JSONObject(json).getJSONArray("pageviews")
+            val pageviews = PageView.Factory.fromJsonArray(array)
+
+            return PageViewEvent(pageviews = pageviews)
+        }
+    }
+}
+
+/**
+ * Represents a single page view event.
+ */
+data class PageView private constructor(
+
+    /**
+     * The page being viewed.
+     */
+    val page: Page,
+
+    /**
+     * RFC3339 formatted timestamp including UTC offset.
+     */
+    val occurredAt: String,
+
+    /**
+     * The opaque user ID which allows correlating user activity.
+     */
+    val opaqueUserId: String,
+
+    /**
+     * The marketplace's unique ID for this page view event.
+     */
+    val id: String,
+
+    /**
+     * The device type where the page view occurred.
+     * Typically "desktop" or "mobile".
+     */
+    val deviceType: String? = null,
+
+    /**
+     * The channel where the page view occurred.
+     * Typically "onsite", "offsite", or "instore".
+     */
+    val channel: String? = null,
+) : JsonSerializable {
+
+    override fun toJsonObject(): JSONObject {
+        return JSONObject()
+            .put("page", page.toJsonObject())
+            .put("occurredAt", occurredAt)
+            .put("opaqueUserId", opaqueUserId)
+            .put("id", id)
+            .apply {
+                deviceType?.let { put("deviceType", it) }
+                channel?.let { put("channel", it) }
+            }
+    }
+
+    object Factory {
+
+        /**
+         * Build a page view event.
+         *
+         * @param page The page being viewed
+         * @param occurredAt RFC3339 formatted timestamp
+         * @param opaqueUserId The opaque user ID
+         * @param id The marketplace's unique ID for this event
+         * @param deviceType Optional device type ("desktop" or "mobile")
+         * @param channel Optional channel ("onsite", "offsite", or "instore")
+         */
+        @JvmOverloads
+        fun build(
+            page: Page,
+            occurredAt: String,
+            opaqueUserId: String,
+            id: String,
+            deviceType: String? = null,
+            channel: String? = null,
+        ): PageView {
+            return PageView(
+                page = page,
+                occurredAt = occurredAt,
+                opaqueUserId = opaqueUserId,
+                id = id,
+                deviceType = deviceType,
+                channel = channel,
+            )
+        }
+
+        fun fromJsonObject(json: JSONObject): PageView {
+            return PageView(
+                page = Page.Factory.fromJsonObject(json.getJSONObject("page")),
+                occurredAt = json.getString("occurredAt"),
+                opaqueUserId = json.getString("opaqueUserId"),
+                id = json.getString("id"),
+                deviceType = json.getStringOrNull("deviceType"),
+                channel = json.getStringOrNull("channel"),
+            )
+        }
+
+        fun fromJsonArray(array: JSONArray): List<PageView> =
+            getListFromJsonArray(array) {
+                fromJsonObject(it)
+            }
+    }
+}
+
+internal data class PageViewEventResponse(
+    val pageviews: List<PageView>
+)

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/model/PageViewEvent.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/model/PageViewEvent.kt
@@ -128,7 +128,3 @@ data class PageView private constructor(
             }
     }
 }
-
-internal data class PageViewEventResponse(
-    val pageviews: List<PageView>
-)

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/model/PageViewEvent.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/model/PageViewEvent.kt
@@ -8,7 +8,7 @@ import org.json.JSONObject
 /**
  * Event representing a page view.
  */
-data class PageViewEvent(
+internal data class PageViewEvent(
     val pageviews: List<PageView>,
 ) {
     fun toJsonObject(): JSONObject {
@@ -33,7 +33,7 @@ data class PageViewEvent(
 /**
  * Represents a single page view event.
  */
-data class PageView private constructor(
+internal data class PageView private constructor(
 
     /**
      * The page being viewed.
@@ -57,16 +57,30 @@ data class PageView private constructor(
 
     /**
      * The device type where the page view occurred.
-     * Typically "desktop" or "mobile".
+     * Use [DEVICE_TYPE_DESKTOP] or [DEVICE_TYPE_MOBILE].
      */
     val deviceType: String? = null,
 
     /**
      * The channel where the page view occurred.
-     * Typically "onsite", "offsite", or "instore".
+     * Use [CHANNEL_ONSITE], [CHANNEL_OFFSITE], or [CHANNEL_INSTORE].
      */
     val channel: String? = null,
 ) : JsonSerializable {
+
+    companion object {
+        /** Device type constant for desktop devices */
+        const val DEVICE_TYPE_DESKTOP = "desktop"
+        /** Device type constant for mobile devices */
+        const val DEVICE_TYPE_MOBILE = "mobile"
+
+        /** Channel constant for onsite events */
+        const val CHANNEL_ONSITE = "onsite"
+        /** Channel constant for offsite events */
+        const val CHANNEL_OFFSITE = "offsite"
+        /** Channel constant for in-store events */
+        const val CHANNEL_INSTORE = "instore"
+    }
 
     override fun toJsonObject(): JSONObject {
         return JSONObject()

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/model/PageViewEvent.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/model/PageViewEvent.kt
@@ -57,30 +57,16 @@ internal data class PageView private constructor(
 
     /**
      * The device type where the page view occurred.
-     * Use [DEVICE_TYPE_DESKTOP] or [DEVICE_TYPE_MOBILE].
+     * Use [Page.DEVICE_TYPE_DESKTOP] or [Page.DEVICE_TYPE_MOBILE].
      */
     val deviceType: String? = null,
 
     /**
      * The channel where the page view occurred.
-     * Use [CHANNEL_ONSITE], [CHANNEL_OFFSITE], or [CHANNEL_INSTORE].
+     * Use [Page.CHANNEL_ONSITE], [Page.CHANNEL_OFFSITE], or [Page.CHANNEL_INSTORE].
      */
     val channel: String? = null,
 ) : JsonSerializable {
-
-    companion object {
-        /** Device type constant for desktop devices */
-        const val DEVICE_TYPE_DESKTOP = "desktop"
-        /** Device type constant for mobile devices */
-        const val DEVICE_TYPE_MOBILE = "mobile"
-
-        /** Channel constant for onsite events */
-        const val CHANNEL_ONSITE = "onsite"
-        /** Channel constant for offsite events */
-        const val CHANNEL_OFFSITE = "offsite"
-        /** Channel constant for in-store events */
-        const val CHANNEL_INSTORE = "instore"
-    }
 
     override fun toJsonObject(): JSONObject {
         return JSONObject()

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/service/TopsortAnalyticsHttpService.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/service/TopsortAnalyticsHttpService.kt
@@ -7,6 +7,7 @@ import com.topsort.analytics.model.auctions.ApiConstants
 import com.topsort.analytics.model.ClickEvent
 import com.topsort.analytics.model.Event
 import com.topsort.analytics.model.ImpressionEvent
+import com.topsort.analytics.model.PageViewEvent
 import com.topsort.analytics.model.PurchaseEvent
 
 internal object TopsortAnalyticsHttpService {
@@ -33,6 +34,10 @@ internal object TopsortAnalyticsHttpService {
                 return reportSerializedEvent(purchaseEvent.toJsonObject().toString())
             }
 
+            override fun reportPageView(pageViewEvent: PageViewEvent): HttpResponse {
+                return reportSerializedEvent(pageViewEvent.toJsonObject().toString())
+            }
+
             override fun reportEvent(event: Event): HttpResponse {
                 return reportSerializedEvent(event.toJsonObject().toString())
             }
@@ -45,6 +50,8 @@ internal object TopsortAnalyticsHttpService {
         fun reportClick(clickEvent: ClickEvent): HttpResponse
 
         fun reportPurchase(purchaseEvent: PurchaseEvent): HttpResponse
+
+        fun reportPageView(pageViewEvent: PageViewEvent): HttpResponse
 
         fun reportEvent(event: Event): HttpResponse
     }

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/worker/EventEmitterWorker.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/worker/EventEmitterWorker.kt
@@ -8,6 +8,7 @@ import com.topsort.analytics.Cache
 import com.topsort.analytics.model.ClickEvent
 import com.topsort.analytics.model.EventType
 import com.topsort.analytics.model.ImpressionEvent
+import com.topsort.analytics.model.PageViewEvent
 import com.topsort.analytics.model.PurchaseEvent
 import com.topsort.analytics.service.TopsortAnalyticsHttpService
 
@@ -26,6 +27,7 @@ internal class EventEmitterWorker(
         Cache.initialize(context)
     }
 
+    @Suppress("detekt:CyclomaticComplexMethod")
     override fun doWork(): Result {
         with (inputData) {
             val eventTypeOrdinal = getInt(EXTRA_EVENT_TYPE, -1)
@@ -50,6 +52,10 @@ internal class EventEmitterWorker(
             EventType.Purchase -> {
                 val event = Cache.readPurchase(recordId) ?: return Result.success()
                 reportPurchase(event)
+            }
+            EventType.PageView -> {
+                val event = Cache.readPageView(recordId) ?: return Result.success()
+                reportPageView(event)
             }
         }
 
@@ -92,6 +98,16 @@ internal class EventEmitterWorker(
             toSendResult(response.code, response.message, "purchase")
         } catch (e: Exception) {
             Log.e(TAG, "Exception reporting purchase", e)
+            SendResult.TRANSIENT_FAILURE
+        }
+    }
+
+    private fun reportPageView(pageViewEvent: PageViewEvent): SendResult {
+        return try {
+            val response = TopsortAnalyticsHttpService.service.reportPageView(pageViewEvent)
+            toSendResult(response.code, response.message, "pageview")
+        } catch (e: Exception) {
+            Log.e(TAG, "Exception reporting pageview", e)
             SendResult.TRANSIENT_FAILURE
         }
     }

--- a/TopsortAnalytics/src/test/java/com/topsort/analytics/model/PageTest.kt
+++ b/TopsortAnalytics/src/test/java/com/topsort/analytics/model/PageTest.kt
@@ -204,4 +204,26 @@ internal class PageTest {
         assertThat(Page.TYPE_CART).isEqualTo("cart")
         assertThat(Page.TYPE_OTHER).isEqualTo("other")
     }
+
+    @Test
+    fun `fromJsonObject handles null value field`() {
+        val json = JSONObject("""{"type": "home", "value": null}""")
+        val page = Page.Factory.fromJsonObject(json)
+
+        assertThat(page.type).isEqualTo("home")
+        assertThat(page.value).isNull()
+        assertThat(page.values).isNull()
+    }
+
+    @Test
+    fun `fromJsonObject handles empty values array`() {
+        val json = JSONObject().apply {
+            put("type", "category")
+            put("value", JSONArray())
+        }
+        val page = Page.Factory.fromJsonObject(json)
+
+        assertThat(page.type).isEqualTo("category")
+        assertThat(page.values).isEmpty()
+    }
 }

--- a/TopsortAnalytics/src/test/java/com/topsort/analytics/model/PageTest.kt
+++ b/TopsortAnalytics/src/test/java/com/topsort/analytics/model/PageTest.kt
@@ -207,6 +207,15 @@ internal class PageTest {
     }
 
     @Test
+    fun `deviceType and channel constants are correct`() {
+        assertThat(Page.DEVICE_TYPE_DESKTOP).isEqualTo("desktop")
+        assertThat(Page.DEVICE_TYPE_MOBILE).isEqualTo("mobile")
+        assertThat(Page.CHANNEL_ONSITE).isEqualTo("onsite")
+        assertThat(Page.CHANNEL_OFFSITE).isEqualTo("offsite")
+        assertThat(Page.CHANNEL_INSTORE).isEqualTo("instore")
+    }
+
+    @Test
     fun `fromJsonObject handles null value field`() {
         val json = JSONObject("""{"type": "home", "value": null}""")
         val page = Page.Factory.fromJsonObject(json)

--- a/TopsortAnalytics/src/test/java/com/topsort/analytics/model/PageTest.kt
+++ b/TopsortAnalytics/src/test/java/com/topsort/analytics/model/PageTest.kt
@@ -1,0 +1,207 @@
+package com.topsort.analytics.model
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Test
+
+internal class PageTest {
+
+    @Test
+    fun `Factory build creates page with type only`() {
+        val page = Page.Factory.build(type = "home")
+
+        assertThat(page.type).isEqualTo("home")
+        assertThat(page.pageId).isNull()
+        assertThat(page.value).isNull()
+        assertThat(page.values).isNull()
+    }
+
+    @Test
+    fun `Factory buildWithId creates page with type and pageId`() {
+        val page = Page.Factory.buildWithId(
+            type = "PDP",
+            pageId = "product-123"
+        )
+
+        assertThat(page.type).isEqualTo("PDP")
+        assertThat(page.pageId).isEqualTo("product-123")
+        assertThat(page.value).isNull()
+        assertThat(page.values).isNull()
+    }
+
+    @Test
+    fun `Factory buildWithId creates page with value`() {
+        val page = Page.Factory.buildWithId(
+            type = "search",
+            pageId = "search-page",
+            value = "shoes"
+        )
+
+        assertThat(page.type).isEqualTo("search")
+        assertThat(page.pageId).isEqualTo("search-page")
+        assertThat(page.value).isEqualTo("shoes")
+        assertThat(page.values).isNull()
+    }
+
+    @Test
+    fun `Factory buildWithValues creates page with values list`() {
+        val page = Page.Factory.buildWithValues(
+            type = "category",
+            values = listOf("Electronics", "Phones", "Smartphones")
+        )
+
+        assertThat(page.type).isEqualTo("category")
+        assertThat(page.pageId).isNull()
+        assertThat(page.value).isNull()
+        assertThat(page.values).containsExactly("Electronics", "Phones", "Smartphones")
+    }
+
+    @Test
+    fun `Factory buildWithValues creates page with pageId and values`() {
+        val page = Page.Factory.buildWithValues(
+            type = "category",
+            values = listOf("Men", "Shoes"),
+            pageId = "cat-123"
+        )
+
+        assertThat(page.type).isEqualTo("category")
+        assertThat(page.pageId).isEqualTo("cat-123")
+        assertThat(page.values).containsExactly("Men", "Shoes")
+    }
+
+    @Test
+    fun `toJsonObject serializes type only`() {
+        val page = Page.Factory.build(type = "home")
+        val json = page.toJsonObject()
+
+        assertThat(json.getString("type")).isEqualTo("home")
+        assertThat(json.has("pageId")).isFalse()
+        assertThat(json.has("value")).isFalse()
+    }
+
+    @Test
+    fun `toJsonObject serializes pageId when present`() {
+        val page = Page.Factory.buildWithId(type = "PDP", pageId = "p-123")
+        val json = page.toJsonObject()
+
+        assertThat(json.getString("type")).isEqualTo("PDP")
+        assertThat(json.getString("pageId")).isEqualTo("p-123")
+    }
+
+    @Test
+    fun `toJsonObject serializes single value as string`() {
+        val page = Page.Factory.buildWithId(
+            type = "search",
+            pageId = "s-1",
+            value = "query"
+        )
+        val json = page.toJsonObject()
+
+        assertThat(json.getString("value")).isEqualTo("query")
+    }
+
+    @Test
+    fun `toJsonObject serializes values as JSON array`() {
+        val page = Page.Factory.buildWithValues(
+            type = "category",
+            values = listOf("A", "B", "C")
+        )
+        val json = page.toJsonObject()
+
+        val valueArray = json.getJSONArray("value")
+        assertThat(valueArray.length()).isEqualTo(3)
+        assertThat(valueArray.getString(0)).isEqualTo("A")
+        assertThat(valueArray.getString(1)).isEqualTo("B")
+        assertThat(valueArray.getString(2)).isEqualTo("C")
+    }
+
+    @Test
+    fun `fromJsonObject parses type only`() {
+        val json = JSONObject("""{"type": "cart"}""")
+        val page = Page.Factory.fromJsonObject(json)
+
+        assertThat(page.type).isEqualTo("cart")
+        assertThat(page.pageId).isNull()
+        assertThat(page.value).isNull()
+        assertThat(page.values).isNull()
+    }
+
+    @Test
+    fun `fromJsonObject parses pageId`() {
+        val json = JSONObject("""{"type": "PDP", "pageId": "prod-456"}""")
+        val page = Page.Factory.fromJsonObject(json)
+
+        assertThat(page.type).isEqualTo("PDP")
+        assertThat(page.pageId).isEqualTo("prod-456")
+    }
+
+    @Test
+    fun `fromJsonObject parses string value`() {
+        val json = JSONObject("""{"type": "search", "value": "laptop"}""")
+        val page = Page.Factory.fromJsonObject(json)
+
+        assertThat(page.type).isEqualTo("search")
+        assertThat(page.value).isEqualTo("laptop")
+        assertThat(page.values).isNull()
+    }
+
+    @Test
+    fun `fromJsonObject parses array value as values list`() {
+        val json = JSONObject().apply {
+            put("type", "category")
+            put("value", JSONArray(listOf("Cat1", "Cat2")))
+        }
+        val page = Page.Factory.fromJsonObject(json)
+
+        assertThat(page.type).isEqualTo("category")
+        assertThat(page.value).isNull()
+        assertThat(page.values).containsExactly("Cat1", "Cat2")
+    }
+
+    @Test
+    fun `roundtrip serialization with type only`() {
+        val original = Page.Factory.build(type = "home")
+        val serialized = original.toJsonObject().toString()
+        val deserialized = Page.Factory.fromJsonObject(JSONObject(serialized))
+
+        assertThat(deserialized).isEqualTo(original)
+    }
+
+    @Test
+    fun `roundtrip serialization with all fields`() {
+        val original = Page.Factory.buildWithId(
+            type = "search",
+            pageId = "search-1",
+            value = "sneakers"
+        )
+        val serialized = original.toJsonObject().toString()
+        val deserialized = Page.Factory.fromJsonObject(JSONObject(serialized))
+
+        assertThat(deserialized).isEqualTo(original)
+    }
+
+    @Test
+    fun `roundtrip serialization with values list`() {
+        val original = Page.Factory.buildWithValues(
+            type = "category",
+            values = listOf("Electronics", "Computers"),
+            pageId = "cat-99"
+        )
+        val serialized = original.toJsonObject().toString()
+        val deserialized = Page.Factory.fromJsonObject(JSONObject(serialized))
+
+        assertThat(deserialized).isEqualTo(original)
+    }
+
+    @Test
+    fun `type constants are correct`() {
+        assertThat(Page.TYPE_HOME).isEqualTo("home")
+        assertThat(Page.TYPE_CATEGORY).isEqualTo("category")
+        assertThat(Page.TYPE_PDP).isEqualTo("PDP")
+        assertThat(Page.TYPE_SEARCH).isEqualTo("search")
+        assertThat(Page.TYPE_CART).isEqualTo("cart")
+        assertThat(Page.TYPE_OTHER).isEqualTo("other")
+    }
+}

--- a/TopsortAnalytics/src/test/java/com/topsort/analytics/model/PageTest.kt
+++ b/TopsortAnalytics/src/test/java/com/topsort/analytics/model/PageTest.kt
@@ -3,6 +3,7 @@ package com.topsort.analytics.model
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.json.JSONArray
+import org.json.JSONException
 import org.json.JSONObject
 import org.junit.Test
 
@@ -222,6 +223,40 @@ internal class PageTest {
             put("value", JSONArray())
         }
         val page = Page.Factory.fromJsonObject(json)
+
+        assertThat(page.type).isEqualTo("category")
+        assertThat(page.values).isEmpty()
+    }
+
+    @Test
+    fun `copy with both value and values throws IllegalArgumentException`() {
+        val page = Page.Factory.buildWithId(
+            type = "search",
+            pageId = "search-1",
+            value = "shoes"
+        )
+
+        assertThatThrownBy {
+            page.copy(values = listOf("A", "B"))
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("mutually exclusive")
+    }
+
+    @Test
+    fun `fromJsonObject with missing type throws JSONException`() {
+        val json = JSONObject("""{"pageId": "p-123", "value": "test"}""")
+
+        assertThatThrownBy {
+            Page.Factory.fromJsonObject(json)
+        }.isInstanceOf(JSONException::class.java)
+    }
+
+    @Test
+    fun `buildWithValues allows empty values list`() {
+        val page = Page.Factory.buildWithValues(
+            type = "category",
+            values = emptyList()
+        )
 
         assertThat(page.type).isEqualTo("category")
         assertThat(page.values).isEmpty()

--- a/TopsortAnalytics/src/test/java/com/topsort/analytics/model/PageViewEventTest.kt
+++ b/TopsortAnalytics/src/test/java/com/topsort/analytics/model/PageViewEventTest.kt
@@ -1,0 +1,254 @@
+package com.topsort.analytics.model
+
+import org.assertj.core.api.Assertions.assertThat
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Test
+
+internal class PageViewEventTest {
+
+    @Test
+    fun `PageView Factory build creates basic page view`() {
+        val page = Page.Factory.build(type = "home")
+        val pageView = PageView.Factory.build(
+            page = page,
+            occurredAt = "2024-01-15T10:30:00Z",
+            opaqueUserId = "user-123",
+            id = "pv-456"
+        )
+
+        assertThat(pageView.page).isEqualTo(page)
+        assertThat(pageView.occurredAt).isEqualTo("2024-01-15T10:30:00Z")
+        assertThat(pageView.opaqueUserId).isEqualTo("user-123")
+        assertThat(pageView.id).isEqualTo("pv-456")
+        assertThat(pageView.deviceType).isNull()
+        assertThat(pageView.channel).isNull()
+    }
+
+    @Test
+    fun `PageView Factory build creates page view with optional fields`() {
+        val page = Page.Factory.buildWithId(type = "PDP", pageId = "prod-1")
+        val pageView = PageView.Factory.build(
+            page = page,
+            occurredAt = "2024-01-15T10:30:00Z",
+            opaqueUserId = "user-123",
+            id = "pv-789",
+            deviceType = "mobile",
+            channel = "onsite"
+        )
+
+        assertThat(pageView.deviceType).isEqualTo("mobile")
+        assertThat(pageView.channel).isEqualTo("onsite")
+    }
+
+    @Test
+    fun `PageView toJsonObject serializes required fields`() {
+        val page = Page.Factory.build(type = "cart")
+        val pageView = PageView.Factory.build(
+            page = page,
+            occurredAt = "2024-01-15T10:30:00Z",
+            opaqueUserId = "user-abc",
+            id = "pv-def"
+        )
+
+        val json = pageView.toJsonObject()
+
+        assertThat(json.getJSONObject("page").getString("type")).isEqualTo("cart")
+        assertThat(json.getString("occurredAt")).isEqualTo("2024-01-15T10:30:00Z")
+        assertThat(json.getString("opaqueUserId")).isEqualTo("user-abc")
+        assertThat(json.getString("id")).isEqualTo("pv-def")
+        assertThat(json.has("deviceType")).isFalse()
+        assertThat(json.has("channel")).isFalse()
+    }
+
+    @Test
+    fun `PageView toJsonObject serializes optional fields when present`() {
+        val page = Page.Factory.build(type = "home")
+        val pageView = PageView.Factory.build(
+            page = page,
+            occurredAt = "2024-01-15T10:30:00Z",
+            opaqueUserId = "user-123",
+            id = "pv-123",
+            deviceType = "desktop",
+            channel = "offsite"
+        )
+
+        val json = pageView.toJsonObject()
+
+        assertThat(json.getString("deviceType")).isEqualTo("desktop")
+        assertThat(json.getString("channel")).isEqualTo("offsite")
+    }
+
+    @Test
+    fun `PageView fromJsonObject parses required fields`() {
+        val json = JSONObject("""
+            {
+                "page": {"type": "search"},
+                "occurredAt": "2024-02-20T15:45:00Z",
+                "opaqueUserId": "user-xyz",
+                "id": "pv-abc"
+            }
+        """.trimIndent())
+
+        val pageView = PageView.Factory.fromJsonObject(json)
+
+        assertThat(pageView.page.type).isEqualTo("search")
+        assertThat(pageView.occurredAt).isEqualTo("2024-02-20T15:45:00Z")
+        assertThat(pageView.opaqueUserId).isEqualTo("user-xyz")
+        assertThat(pageView.id).isEqualTo("pv-abc")
+        assertThat(pageView.deviceType).isNull()
+        assertThat(pageView.channel).isNull()
+    }
+
+    @Test
+    fun `PageView fromJsonObject parses optional fields`() {
+        val json = JSONObject("""
+            {
+                "page": {"type": "PDP", "pageId": "prod-99"},
+                "occurredAt": "2024-02-20T15:45:00Z",
+                "opaqueUserId": "user-xyz",
+                "id": "pv-abc",
+                "deviceType": "mobile",
+                "channel": "instore"
+            }
+        """.trimIndent())
+
+        val pageView = PageView.Factory.fromJsonObject(json)
+
+        assertThat(pageView.page.pageId).isEqualTo("prod-99")
+        assertThat(pageView.deviceType).isEqualTo("mobile")
+        assertThat(pageView.channel).isEqualTo("instore")
+    }
+
+    @Test
+    fun `PageView roundtrip serialization`() {
+        val page = Page.Factory.buildWithId(type = "category", pageId = "cat-1")
+        val original = PageView.Factory.build(
+            page = page,
+            occurredAt = "2024-03-01T12:00:00Z",
+            opaqueUserId = "user-roundtrip",
+            id = "pv-roundtrip",
+            deviceType = "mobile",
+            channel = "onsite"
+        )
+
+        val serialized = original.toJsonObject().toString()
+        val deserialized = PageView.Factory.fromJsonObject(JSONObject(serialized))
+
+        assertThat(deserialized).isEqualTo(original)
+    }
+
+    @Test
+    fun `PageView fromJsonArray parses multiple page views`() {
+        val jsonArray = JSONArray().apply {
+            put(JSONObject("""
+                {
+                    "page": {"type": "home"},
+                    "occurredAt": "2024-01-01T00:00:00Z",
+                    "opaqueUserId": "user-1",
+                    "id": "pv-1"
+                }
+            """.trimIndent()))
+            put(JSONObject("""
+                {
+                    "page": {"type": "cart"},
+                    "occurredAt": "2024-01-01T00:01:00Z",
+                    "opaqueUserId": "user-1",
+                    "id": "pv-2"
+                }
+            """.trimIndent()))
+        }
+
+        val pageViews = PageView.Factory.fromJsonArray(jsonArray)
+
+        assertThat(pageViews).hasSize(2)
+        assertThat(pageViews[0].page.type).isEqualTo("home")
+        assertThat(pageViews[1].page.type).isEqualTo("cart")
+    }
+
+    @Test
+    fun `PageViewEvent toJsonObject serializes pageviews array`() {
+        val pageView1 = PageView.Factory.build(
+            page = Page.Factory.build(type = "home"),
+            occurredAt = "2024-01-01T00:00:00Z",
+            opaqueUserId = "user-1",
+            id = "pv-1"
+        )
+        val pageView2 = PageView.Factory.build(
+            page = Page.Factory.build(type = "PDP"),
+            occurredAt = "2024-01-01T00:05:00Z",
+            opaqueUserId = "user-1",
+            id = "pv-2"
+        )
+
+        val event = PageViewEvent(pageviews = listOf(pageView1, pageView2))
+        val json = event.toJsonObject()
+
+        val pageviewsArray = json.getJSONArray("pageviews")
+        assertThat(pageviewsArray.length()).isEqualTo(2)
+        assertThat(pageviewsArray.getJSONObject(0).getString("id")).isEqualTo("pv-1")
+        assertThat(pageviewsArray.getJSONObject(1).getString("id")).isEqualTo("pv-2")
+    }
+
+    @Test
+    fun `PageViewEvent fromJson returns null for null input`() {
+        val result = PageViewEvent.fromJson(null)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `PageViewEvent fromJson parses valid JSON`() {
+        val json = """
+            {
+                "pageviews": [
+                    {
+                        "page": {"type": "search", "value": "shoes"},
+                        "occurredAt": "2024-05-10T08:00:00Z",
+                        "opaqueUserId": "user-search",
+                        "id": "pv-search"
+                    }
+                ]
+            }
+        """.trimIndent()
+
+        val event = PageViewEvent.fromJson(json)
+
+        assertThat(event).isNotNull
+        assertThat(event!!.pageviews).hasSize(1)
+        assertThat(event.pageviews[0].page.type).isEqualTo("search")
+        assertThat(event.pageviews[0].page.value).isEqualTo("shoes")
+    }
+
+    @Test
+    fun `PageViewEvent roundtrip serialization`() {
+        val pageView = PageView.Factory.build(
+            page = Page.Factory.buildWithValues(
+                type = "category",
+                values = listOf("Electronics", "Phones")
+            ),
+            occurredAt = "2024-06-15T14:30:00Z",
+            opaqueUserId = "user-rt",
+            id = "pv-rt",
+            deviceType = "desktop",
+            channel = "onsite"
+        )
+
+        val original = PageViewEvent(pageviews = listOf(pageView))
+        val serialized = original.toJsonObject().toString()
+        val deserialized = PageViewEvent.fromJson(serialized)
+
+        assertThat(deserialized).isNotNull
+        assertThat(deserialized!!.pageviews).hasSize(1)
+        assertThat(deserialized.pageviews[0]).isEqualTo(pageView)
+    }
+
+    @Test
+    fun `PageViewEvent with empty pageviews list`() {
+        val event = PageViewEvent(pageviews = emptyList())
+        val json = event.toJsonObject()
+
+        val pageviewsArray = json.getJSONArray("pageviews")
+        assertThat(pageviewsArray.length()).isEqualTo(0)
+    }
+}

--- a/TopsortAnalytics/src/test/java/com/topsort/analytics/model/PageViewEventTest.kt
+++ b/TopsortAnalytics/src/test/java/com/topsort/analytics/model/PageViewEventTest.kt
@@ -121,7 +121,7 @@ internal class PageViewEventTest {
     }
 
     @Test
-    fun `PageView roundtrip serialization`() {
+    fun `PageView roundtrip serialization with all fields`() {
         val page = Page.Factory.buildWithId(type = "category", pageId = "cat-1")
         val original = PageView.Factory.build(
             page = page,
@@ -136,6 +136,24 @@ internal class PageViewEventTest {
         val deserialized = PageView.Factory.fromJsonObject(JSONObject(serialized))
 
         assertThat(deserialized).isEqualTo(original)
+    }
+
+    @Test
+    fun `PageView roundtrip serialization with required fields only`() {
+        val page = Page.Factory.build(type = "home")
+        val original = PageView.Factory.build(
+            page = page,
+            occurredAt = "2024-03-01T12:00:00Z",
+            opaqueUserId = "user-minimal",
+            id = "pv-minimal"
+        )
+
+        val serialized = original.toJsonObject().toString()
+        val deserialized = PageView.Factory.fromJsonObject(JSONObject(serialized))
+
+        assertThat(deserialized).isEqualTo(original)
+        assertThat(deserialized.deviceType).isNull()
+        assertThat(deserialized.channel).isNull()
     }
 
     @Test


### PR DESCRIPTION
## Summary

Add `Page` model and `PageView` event tracking to enable page-level analytics, aligning the Android SDK with the iOS SDK capabilities.

## Motivation

Page view tracking allows marketplaces to:
- Understand user navigation patterns
- Correlate page views with conversions
- Analyze funnel performance across page types

## Changes

### New Models

**`Page`** (public) - Represents page context
- `type`: Page type (`home`, `category`, `PDP`, `search`, `cart`, `other`)
- `pageId`: Optional identifier
- `value`/`values`: Mutually exclusive - single string or list (e.g., category hierarchy)
- Factory methods enforce valid state via private constructor
- Type constants in companion object (`TYPE_HOME`, `TYPE_PDP`, etc.)

**`PageView`** (internal) - Individual page view event
- `page`, `occurredAt`, `opaqueUserId`, `id` (required)
- `deviceType`, `channel` (optional)
- Constants for deviceType (`DEVICE_TYPE_DESKTOP`, `DEVICE_TYPE_MOBILE`)
- Constants for channel (`CHANNEL_ONSITE`, `CHANNEL_OFFSITE`, `CHANNEL_INSTORE`)

**`PageViewEvent`** (internal) - Container for batch sending

### API Changes

```kotlin
// New method with default implementation (backward compatible)
interface TopsortAnalytics {
    fun reportPageView(
        page: Page,
        opaqueUserId: String? = null,
        id: String? = null,
        occurredAt: String? = null,
        deviceType: String? = null,
        channel: String? = null,
    ) { } // default empty - won't break existing implementors
}
```

### Files Changed

**New:**
- `model/Page.kt` - Page model with Factory and type constants
- `model/PageViewEvent.kt` - PageView and PageViewEvent models (internal)
- `model/PageTest.kt` - 19 unit tests
- `model/PageViewEventTest.kt` - 15 unit tests

**Modified:**
- `TopsortAnalytics.kt` - Add `reportPageView()` with default implementation
- `Analytics.kt` - Implement `reportPageView()`
- `Cache.kt` - Add pageview persistence
- `EventEmitterWorker.kt` - Add PageView dispatch
- `TopsortAnalyticsHttpService.kt` - Add `reportPageView()` to service
- `EventType.kt` - Add `PageView` enum
- `TopsortAnalytics.api` - Updated API dump

## Architecture Notes

- **Internal by default**: `PageView` and `PageViewEvent` are `internal` - only `Page` is public since users need to construct it
- **JSON serialization**: Both `value` (string) and `values` (list) serialize to the same JSON key `"value"` - the API distinguishes them by JSON type (string vs array)
- **Factory pattern**: Private constructors with Factory methods prevent invalid state

## Backward Compatibility

| Change | Impact |
|--------|--------|
| New `reportPageView()` method | ✅ Has default implementation |
| New `Page` class (public) | ✅ Additive only |
| New `PageView`/`PageViewEvent` (internal) | ✅ Not part of public API |
| New `EventType.PageView` enum | ✅ Internal enum |

**Existing code will compile and work without changes.**

## Usage Examples

```kotlin
// Home page
Analytics.reportPageView(
    page = Page.Factory.build(type = Page.TYPE_HOME)
)

// Product detail page
Analytics.reportPageView(
    page = Page.Factory.buildWithId(
        type = Page.TYPE_PDP,
        pageId = "product-123"
    ),
    deviceType = "mobile",
    channel = "onsite"
)

// Category with hierarchy
Analytics.reportPageView(
    page = Page.Factory.buildWithValues(
        type = Page.TYPE_CATEGORY,
        values = listOf("Electronics", "Phones")
    )
)

// Search with query
Analytics.reportPageView(
    page = Page.Factory.buildWithId(
        type = Page.TYPE_SEARCH,
        pageId = "search",
        value = "running shoes"
    )
)
```

## Test Coverage

- **34 unit tests** covering:
  - All Factory methods
  - JSON serialization/deserialization roundtrips
  - Edge cases (null values, empty arrays)
  - Type constants validation
  - PageViewEvent batch serialization

## Checklist

- [x] Backward compatible (default implementation on interface)
- [x] Unit tests added (34 tests)
- [x] API dump updated
- [x] Internal classes properly scoped
- [x] Constants added for deviceType and channel
- [x] No dead code (removed unused `PageViewEventResponse`)
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)