### PR TITLE
feat: add response enhancements (campaignId, Asset.content)

### DIFF
--- a/TopsortAnalytics/api/TopsortAnalytics.api
+++ b/TopsortAnalytics/api/TopsortAnalytics.api
@@ -880,11 +880,14 @@ public final class com/topsort/analytics/model/auctions/AuctionResponse {
 
 public final class com/topsort/analytics/model/auctions/AuctionResponse$Asset {
 	public static final field Companion Lcom/topsort/analytics/model/auctions/AuctionResponse$Asset$Companion;
-	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/topsort/analytics/model/auctions/AuctionResponse$Asset;
-	public static synthetic fun copy$default (Lcom/topsort/analytics/model/auctions/AuctionResponse$Asset;Ljava/lang/String;ILjava/lang/Object;)Lcom/topsort/analytics/model/auctions/AuctionResponse$Asset;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/topsort/analytics/model/auctions/AuctionResponse$Asset;
+	public static synthetic fun copy$default (Lcom/topsort/analytics/model/auctions/AuctionResponse$Asset;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/topsort/analytics/model/auctions/AuctionResponse$Asset;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContent ()Ljava/lang/String;
 	public final fun getUrl ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -916,17 +919,19 @@ public final class com/topsort/analytics/model/auctions/AuctionResponse$AuctionR
 
 public final class com/topsort/analytics/model/auctions/AuctionResponse$AuctionWinnerItem {
 	public static final field Companion Lcom/topsort/analytics/model/auctions/AuctionResponse$AuctionWinnerItem$Companion;
-	public fun <init> (ILcom/topsort/analytics/model/auctions/EntityType;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
-	public synthetic fun <init> (ILcom/topsort/analytics/model/auctions/EntityType;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ILcom/topsort/analytics/model/auctions/EntityType;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (ILcom/topsort/analytics/model/auctions/EntityType;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()I
 	public final fun component2 ()Lcom/topsort/analytics/model/auctions/EntityType;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/util/List;
-	public final fun copy (ILcom/topsort/analytics/model/auctions/EntityType;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lcom/topsort/analytics/model/auctions/AuctionResponse$AuctionWinnerItem;
-	public static synthetic fun copy$default (Lcom/topsort/analytics/model/auctions/AuctionResponse$AuctionWinnerItem;ILcom/topsort/analytics/model/auctions/EntityType;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lcom/topsort/analytics/model/auctions/AuctionResponse$AuctionWinnerItem;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (ILcom/topsort/analytics/model/auctions/EntityType;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)Lcom/topsort/analytics/model/auctions/AuctionResponse$AuctionWinnerItem;
+	public static synthetic fun copy$default (Lcom/topsort/analytics/model/auctions/AuctionResponse$AuctionWinnerItem;ILcom/topsort/analytics/model/auctions/EntityType;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lcom/topsort/analytics/model/auctions/AuctionResponse$AuctionWinnerItem;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAsset ()Ljava/util/List;
+	public final fun getCampaignId ()Ljava/lang/String;
 	public final fun getId ()Ljava/lang/String;
 	public final fun getRank ()I
 	public final fun getResolvedBidId ()Ljava/lang/String;

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/model/auctions/AuctionResponse.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/model/auctions/AuctionResponse.kt
@@ -1,5 +1,6 @@
 package com.topsort.analytics.model.auctions
 
+import com.topsort.analytics.core.getStringOrNull
 import org.json.JSONObject
 
 data class AuctionResponse private constructor(
@@ -96,7 +97,7 @@ data class AuctionResponse private constructor(
                         id = json.getString("id"),
                         resolvedBidId = json.getString("resolvedBidId"),
                         asset = assets,
-                        campaignId = json.optString("campaignId", null),
+                        campaignId = json.getStringOrNull("campaignId"),
                     )
                 } catch (e: AuctionError) {
                     throw e
@@ -118,7 +119,7 @@ data class AuctionResponse private constructor(
             fun fromJsonObject(json: JSONObject): Asset {
                 try {
                     val url = json.getString("url")
-                    val content = json.optString("content", null)
+                    val content = json.getStringOrNull("content")
                     return Asset(url = url, content = content)
                 } catch (e: Exception) {
                     throw AuctionError.DeserializationError(e, json.toString().toByteArray())

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/model/auctions/AuctionResponse.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/model/auctions/AuctionResponse.kt
@@ -75,6 +75,10 @@ data class AuctionResponse private constructor(
         val id: String,
         val resolvedBidId: String,
         val asset: List<Asset>? = null,
+        /**
+         * The campaign ID associated with this winning bid.
+         */
+        val campaignId: String? = null,
     ) {
         companion object {
             fun fromJsonObject(json: JSONObject): AuctionWinnerItem {
@@ -92,6 +96,7 @@ data class AuctionResponse private constructor(
                         id = json.getString("id"),
                         resolvedBidId = json.getString("resolvedBidId"),
                         asset = assets,
+                        campaignId = json.optString("campaignId", null),
                     )
                 } catch (e: AuctionError) {
                     throw e
@@ -102,12 +107,19 @@ data class AuctionResponse private constructor(
         }
     }
 
-    data class Asset(val url: String) {
+    data class Asset(
+        val url: String,
+        /**
+         * Optional content associated with the asset (e.g., HTML or text content).
+         */
+        val content: String? = null,
+    ) {
         companion object {
             fun fromJsonObject(json: JSONObject): Asset {
                 try {
                     val url = json.getString("url")
-                    return Asset(url = url)
+                    val content = json.optString("content", null)
+                    return Asset(url = url, content = content)
                 } catch (e: Exception) {
                     throw AuctionError.DeserializationError(e, json.toString().toByteArray())
                 }

--- a/TopsortAnalytics/src/main/java/com/topsort/analytics/model/auctions/AuctionResponse.kt
+++ b/TopsortAnalytics/src/main/java/com/topsort/analytics/model/auctions/AuctionResponse.kt
@@ -3,15 +3,28 @@ package com.topsort.analytics.model.auctions
 import com.topsort.analytics.core.getStringOrNull
 import org.json.JSONObject
 
+/**
+ * Response from the Topsort auction API containing the results of one or more auctions.
+ *
+ * @property results List of auction results, one per auction in the request.
+ */
 data class AuctionResponse private constructor(
     val results: List<AuctionResponseItem>,
 ) {
     companion object {
-        fun fromJson(json: String?): AuctionResponse? {
+        /**
+         * Parses an [AuctionResponse] from a JSON string.
+         *
+         * @param json The JSON string to parse.
+         * @return The parsed [AuctionResponse].
+         * @throws AuctionError.EmptyResponse if [json] is null.
+         * @throws AuctionError.DeserializationError if the JSON is malformed or missing required fields.
+         */
+        fun fromJson(json: String?): AuctionResponse {
             if (json == null) {
                 throw AuctionError.EmptyResponse
             }
-            
+
             try {
                 val jsonObject = JSONObject(json)
                 if (!jsonObject.has("results")) {
@@ -20,15 +33,13 @@ data class AuctionResponse private constructor(
                         json.toByteArray()
                     )
                 }
-                
+
                 val array = jsonObject.getJSONArray("results")
                 val results = (0 until array.length()).map {
                     AuctionResponseItem.fromJsonObject(array.getJSONObject(it))
                 }
 
-                return AuctionResponse(
-                    results = results,
-                )
+                return AuctionResponse(results = results)
             } catch (e: AuctionError) {
                 throw e
             } catch (e: Exception) {
@@ -37,12 +48,24 @@ data class AuctionResponse private constructor(
         }
     }
 
+    /**
+     * A single auction result containing the winning bids.
+     *
+     * @property resultType The type of auction result (e.g., "listings", "banners").
+     * @property winners List of winning bids for this auction, ordered by rank.
+     * @property error Whether an error occurred processing this auction.
+     */
     data class AuctionResponseItem(
         val resultType: String,
         val winners: List<AuctionWinnerItem>,
         val error: Boolean,
     ) {
         companion object {
+            /**
+             * Parses an [AuctionResponseItem] from a [JSONObject].
+             *
+             * @throws AuctionError.DeserializationError if required fields are missing.
+             */
             fun fromJsonObject(json: JSONObject): AuctionResponseItem {
                 try {
                     if (!json.has("winners")) {
@@ -51,7 +74,7 @@ data class AuctionResponse private constructor(
                             json.toString().toByteArray()
                         )
                     }
-                    
+
                     val array = json.getJSONArray("winners")
                     val winners = (0 until array.length()).map {
                         AuctionWinnerItem.fromJsonObject(array.getJSONObject(it))
@@ -70,25 +93,36 @@ data class AuctionResponse private constructor(
         }
     }
 
+    /**
+     * A winning bid in an auction result.
+     *
+     * @property rank The rank of this winner (1 = highest).
+     * @property type The entity type of the winner (product, vendor, etc.).
+     * @property id The marketplace ID of the winning entity.
+     * @property resolvedBidId The unique identifier for this winning bid, used for attribution.
+     * @property asset Optional list of creative assets associated with this winner.
+     * @property campaignId The campaign ID associated with this winning bid.
+     */
     data class AuctionWinnerItem(
         val rank: Int,
         val type: EntityType,
         val id: String,
         val resolvedBidId: String,
         val asset: List<Asset>? = null,
-        /**
-         * The campaign ID associated with this winning bid.
-         */
         val campaignId: String? = null,
     ) {
         companion object {
+            /**
+             * Parses an [AuctionWinnerItem] from a [JSONObject].
+             *
+             * @throws AuctionError.DeserializationError if required fields are missing or invalid.
+             */
             fun fromJsonObject(json: JSONObject): AuctionWinnerItem {
                 try {
                     val assetArray = json.optJSONArray("asset")
-                    var assets: List<Asset>? = null
-                    if (assetArray != null) {
-                        assets = (0 until assetArray.length()).map {
-                            Asset.fromJsonObject(assetArray.getJSONObject(it))
+                    val assets = assetArray?.let { array ->
+                        (0 until array.length()).map {
+                            Asset.fromJsonObject(array.getJSONObject(it))
                         }
                     }
                     return AuctionWinnerItem(
@@ -108,19 +142,28 @@ data class AuctionResponse private constructor(
         }
     }
 
+    /**
+     * A creative asset associated with a winning bid.
+     *
+     * @property url The URL of the asset (e.g., image, video).
+     * @property content Optional content associated with the asset (e.g., HTML or text content).
+     */
     data class Asset(
         val url: String,
-        /**
-         * Optional content associated with the asset (e.g., HTML or text content).
-         */
         val content: String? = null,
     ) {
         companion object {
+            /**
+             * Parses an [Asset] from a [JSONObject].
+             *
+             * @throws AuctionError.DeserializationError if the URL field is missing.
+             */
             fun fromJsonObject(json: JSONObject): Asset {
                 try {
-                    val url = json.getString("url")
-                    val content = json.getStringOrNull("content")
-                    return Asset(url = url, content = content)
+                    return Asset(
+                        url = json.getString("url"),
+                        content = json.getStringOrNull("content"),
+                    )
                 } catch (e: Exception) {
                     throw AuctionError.DeserializationError(e, json.toString().toByteArray())
                 }

--- a/TopsortAnalytics/src/test/java/com/topsort/analytics/model/auctions/AuctionResponseTest.kt
+++ b/TopsortAnalytics/src/test/java/com/topsort/analytics/model/auctions/AuctionResponseTest.kt
@@ -1,9 +1,96 @@
 package com.topsort.analytics.model.auctions
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.json.JSONObject
 import org.junit.Test
 
 class AuctionResponseTest {
+
+    // ==================== Error handling tests ====================
+
+    @Test
+    fun `fromJson throws EmptyResponse when json is null`() {
+        assertThatThrownBy {
+            AuctionResponse.fromJson(null)
+        }.isInstanceOf(AuctionError.EmptyResponse::class.java)
+    }
+
+    @Test
+    fun `fromJson throws DeserializationError when results field is missing`() {
+        val json = """{"something": "else"}"""
+
+        assertThatThrownBy {
+            AuctionResponse.fromJson(json)
+        }.isInstanceOf(AuctionError.DeserializationError::class.java)
+    }
+
+    @Test
+    fun `fromJson throws DeserializationError when json is malformed`() {
+        val json = "not valid json"
+
+        assertThatThrownBy {
+            AuctionResponse.fromJson(json)
+        }.isInstanceOf(AuctionError.DeserializationError::class.java)
+    }
+
+    @Test
+    fun `fromJson parses empty results array`() {
+        val json = """{"results": []}"""
+
+        val response = AuctionResponse.fromJson(json)
+
+        assertThat(response.results).isEmpty()
+    }
+
+    @Test
+    fun `AuctionResponseItem throws DeserializationError when winners field is missing`() {
+        val json = JSONObject().apply {
+            put("resultType", "listings")
+            put("error", false)
+        }
+
+        assertThatThrownBy {
+            AuctionResponse.AuctionResponseItem.fromJsonObject(json)
+        }.isInstanceOf(AuctionError.DeserializationError::class.java)
+    }
+
+    @Test
+    fun `AuctionResponseItem throws DeserializationError when resultType is missing`() {
+        val json = JSONObject().apply {
+            put("winners", org.json.JSONArray())
+            put("error", false)
+        }
+
+        assertThatThrownBy {
+            AuctionResponse.AuctionResponseItem.fromJsonObject(json)
+        }.isInstanceOf(AuctionError.DeserializationError::class.java)
+    }
+
+    @Test
+    fun `AuctionWinnerItem throws DeserializationError when required fields are missing`() {
+        val json = JSONObject().apply {
+            put("rank", 1)
+            // missing type, id, resolvedBidId
+        }
+
+        assertThatThrownBy {
+            AuctionResponse.AuctionWinnerItem.fromJsonObject(json)
+        }.isInstanceOf(AuctionError.DeserializationError::class.java)
+    }
+
+    @Test
+    fun `Asset throws DeserializationError when url is missing`() {
+        val json = JSONObject().apply {
+            put("content", "some content")
+        }
+
+        assertThatThrownBy {
+            AuctionResponse.Asset.fromJsonObject(json)
+        }.isInstanceOf(AuctionError.DeserializationError::class.java)
+    }
+
+    // ==================== Happy path tests ====================
 
     @Test
     fun `AuctionWinnerItem parses campaignId when present`() {
@@ -173,8 +260,7 @@ class AuctionResponseTest {
 
         val response = AuctionResponse.fromJson(json)
 
-        assertThat(response).isNotNull
-        assertThat(response!!.results).hasSize(1)
+        assertThat(response.results).hasSize(1)
         assertThat(response.results[0].winners).hasSize(2)
 
         val winner1 = response.results[0].winners[0]

--- a/TopsortAnalytics/src/test/java/com/topsort/analytics/model/auctions/AuctionResponseTest.kt
+++ b/TopsortAnalytics/src/test/java/com/topsort/analytics/model/auctions/AuctionResponseTest.kt
@@ -1,0 +1,161 @@
+package com.topsort.analytics.model.auctions
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class AuctionResponseTest {
+
+    @Test
+    fun `AuctionWinnerItem parses campaignId when present`() {
+        val json = """
+            {
+                "rank": 1,
+                "type": "product",
+                "id": "product-123",
+                "resolvedBidId": "bid-456",
+                "campaignId": "campaign-789"
+            }
+        """.trimIndent()
+
+        val winner = AuctionResponse.AuctionWinnerItem.fromJsonObject(
+            org.json.JSONObject(json)
+        )
+
+        assertThat(winner.rank).isEqualTo(1)
+        assertThat(winner.type).isEqualTo(EntityType.PRODUCT)
+        assertThat(winner.id).isEqualTo("product-123")
+        assertThat(winner.resolvedBidId).isEqualTo("bid-456")
+        assertThat(winner.campaignId).isEqualTo("campaign-789")
+    }
+
+    @Test
+    fun `AuctionWinnerItem campaignId is null when absent`() {
+        val json = """
+            {
+                "rank": 1,
+                "type": "product",
+                "id": "product-123",
+                "resolvedBidId": "bid-456"
+            }
+        """.trimIndent()
+
+        val winner = AuctionResponse.AuctionWinnerItem.fromJsonObject(
+            org.json.JSONObject(json)
+        )
+
+        assertThat(winner.campaignId).isNull()
+    }
+
+    @Test
+    fun `Asset parses content when present`() {
+        val json = """
+            {
+                "url": "https://example.com/banner.png",
+                "content": "<div>Banner HTML content</div>"
+            }
+        """.trimIndent()
+
+        val asset = AuctionResponse.Asset.fromJsonObject(
+            org.json.JSONObject(json)
+        )
+
+        assertThat(asset.url).isEqualTo("https://example.com/banner.png")
+        assertThat(asset.content).isEqualTo("<div>Banner HTML content</div>")
+    }
+
+    @Test
+    fun `Asset content is null when absent`() {
+        val json = """
+            {
+                "url": "https://example.com/banner.png"
+            }
+        """.trimIndent()
+
+        val asset = AuctionResponse.Asset.fromJsonObject(
+            org.json.JSONObject(json)
+        )
+
+        assertThat(asset.url).isEqualTo("https://example.com/banner.png")
+        assertThat(asset.content).isNull()
+    }
+
+    @Test
+    fun `AuctionWinnerItem parses with assets including content`() {
+        val json = """
+            {
+                "rank": 1,
+                "type": "vendor",
+                "id": "vendor-123",
+                "resolvedBidId": "bid-456",
+                "campaignId": "campaign-001",
+                "asset": [
+                    {
+                        "url": "https://example.com/img1.png",
+                        "content": "Content 1"
+                    },
+                    {
+                        "url": "https://example.com/img2.png"
+                    }
+                ]
+            }
+        """.trimIndent()
+
+        val winner = AuctionResponse.AuctionWinnerItem.fromJsonObject(
+            org.json.JSONObject(json)
+        )
+
+        assertThat(winner.campaignId).isEqualTo("campaign-001")
+        assertThat(winner.asset).hasSize(2)
+        assertThat(winner.asset!![0].url).isEqualTo("https://example.com/img1.png")
+        assertThat(winner.asset!![0].content).isEqualTo("Content 1")
+        assertThat(winner.asset!![1].url).isEqualTo("https://example.com/img2.png")
+        assertThat(winner.asset!![1].content).isNull()
+    }
+
+    @Test
+    fun `full AuctionResponse parses with new fields`() {
+        val json = """
+            {
+                "results": [
+                    {
+                        "resultType": "listings",
+                        "error": false,
+                        "winners": [
+                            {
+                                "rank": 1,
+                                "type": "product",
+                                "id": "p1",
+                                "resolvedBidId": "bid1",
+                                "campaignId": "camp1",
+                                "asset": [
+                                    {"url": "https://example.com/a.png", "content": "Hello"}
+                                ]
+                            },
+                            {
+                                "rank": 2,
+                                "type": "product",
+                                "id": "p2",
+                                "resolvedBidId": "bid2"
+                            }
+                        ]
+                    }
+                ]
+            }
+        """.trimIndent()
+
+        val response = AuctionResponse.fromJson(json)
+
+        assertThat(response).isNotNull
+        assertThat(response!!.results).hasSize(1)
+        assertThat(response.results[0].winners).hasSize(2)
+
+        val winner1 = response.results[0].winners[0]
+        assertThat(winner1.campaignId).isEqualTo("camp1")
+        assertThat(winner1.asset).hasSize(1)
+        assertThat(winner1.asset!![0].content).isEqualTo("Hello")
+
+        val winner2 = response.results[0].winners[1]
+        assertThat(winner2.campaignId).isNull()
+        assertThat(winner2.asset).isNull()
+    }
+}

--- a/TopsortAnalytics/src/test/java/com/topsort/analytics/model/auctions/AuctionResponseTest.kt
+++ b/TopsortAnalytics/src/test/java/com/topsort/analytics/model/auctions/AuctionResponseTest.kt
@@ -47,6 +47,21 @@ class AuctionResponseTest {
     }
 
     @Test
+    fun `AuctionWinnerItem campaignId is null when explicitly null in JSON`() {
+        val json = org.json.JSONObject().apply {
+            put("rank", 1)
+            put("type", "product")
+            put("id", "product-123")
+            put("resolvedBidId", "bid-456")
+            put("campaignId", org.json.JSONObject.NULL)
+        }
+
+        val winner = AuctionResponse.AuctionWinnerItem.fromJsonObject(json)
+
+        assertThat(winner.campaignId).isNull()
+    }
+
+    @Test
     fun `Asset parses content when present`() {
         val json = """
             {
@@ -74,6 +89,19 @@ class AuctionResponseTest {
         val asset = AuctionResponse.Asset.fromJsonObject(
             org.json.JSONObject(json)
         )
+
+        assertThat(asset.url).isEqualTo("https://example.com/banner.png")
+        assertThat(asset.content).isNull()
+    }
+
+    @Test
+    fun `Asset content is null when explicitly null in JSON`() {
+        val json = org.json.JSONObject().apply {
+            put("url", "https://example.com/banner.png")
+            put("content", org.json.JSONObject.NULL)
+        }
+
+        val asset = AuctionResponse.Asset.fromJsonObject(json)
 
         assertThat(asset.url).isEqualTo("https://example.com/banner.png")
         assertThat(asset.content).isNull()


### PR DESCRIPTION
## Summary

This PR adds response enhancements to the auction API, making campaign and asset content information available to consumers.

**This is PR 5 of 6** from the original #112 decomposition.

## New Features

### 1. Campaign Attribution on Winners

Access the `campaignId` associated with each winning bid:

```kotlin
val response = auctionsService.runAuctionsSync(request)

response.results.forEach { result ->
    result.winners.forEach { winner ->
        println("Product: ${winner.id}")
        println("Bid ID: ${winner.resolvedBidId}")
        println("Campaign: ${winner.campaignId}") // NEW - may be null
    }
}
```

### 2. Asset Content

Assets now include an optional `content` field for HTML or text content:

```kotlin
winner.asset?.forEach { asset ->
    println("Image URL: ${asset.url}")
    
    // NEW - Optional HTML/text content associated with the asset
    asset.content?.let { html ->
        webView.loadData(html, "text/html", "UTF-8")
    }
}
```

## API Changes

### `AuctionResponse.AuctionWinnerItem`
| Field | Type | Description |
|-------|------|-------------|
| `campaignId` | `String?` | **NEW** - Campaign ID associated with the winning bid |

### `AuctionResponse.Asset`
| Field | Type | Description |
|-------|------|-------------|
| `content` | `String?` | **NEW** - Optional HTML or text content |

### `AuctionResponse.Companion.fromJson`
- Return type changed from `AuctionResponse?` to `AuctionResponse` (always throws on error, never returns null)

## Other Improvements

- Added comprehensive KDoc documentation to all `AuctionResponse` classes
- Added error handling tests (null input, malformed JSON, missing fields)
- Uses `getStringOrNull` extension for consistent null-safe JSON parsing

## Test Plan

- [x] Unit tests for `campaignId` present/absent/null
- [x] Unit tests for `content` present/absent/null  
- [x] Error handling tests for malformed responses
- [x] Full response parsing integration test
- [x] CI runs unit tests and detekt

🤖 Generated with [Claude Code](https://claude.com/claude-code)