### PR TITLE
chore(ci): remove codecov integration

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,13 +37,6 @@ jobs:
       - name: Generate coverage report
         run: ./gradlew :TopsortAnalytics:koverHtmlReport :TopsortAnalytics:koverXmlReport :TopsortAnalytics:koverVerify
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d  # v5.4.2
-        with:
-          files: TopsortAnalytics/build/reports/kover/xml/report.xml
-          flags: unittests
-          fail_ci_if_error: false
-
       - name: Upload coverage report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: always()

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![API](https://img.shields.io/badge/API-24%2B-brightgreen.svg)](https://android-arsenal.com/api?level=24)
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.0-blue.svg)](https://kotlinlang.org)
 [![CI](https://github.com/Topsort/topsort.kt/actions/workflows/tests.yaml/badge.svg)](https://github.com/Topsort/topsort.kt/actions/workflows/tests.yaml)
-[![codecov](https://codecov.io/gh/Topsort/topsort.kt/branch/main/graph/badge.svg)](https://codecov.io/gh/Topsort/topsort.kt)
 
 The official Android SDK for the [Topsort](https://www.topsort.com) retail media platform. Track impressions, clicks, purchases, and page views with full support for promoted and organic content attribution.
 


### PR DESCRIPTION
We weren't really using this and the recent changes in ownership made us to reassess the usage of Codecov.
